### PR TITLE
sort only ds and y columns on fit

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ ts
 
 
 
-    TimeSeries(freq=<Day>, transforms=['lag-7', 'lag-14', 'expanding_mean_lag-1', 'rolling_mean_lag-7_window_size-7', 'rolling_mean_lag-7_window_size-14'], date_features=['dayofweek', 'month'], num_threads=8)
+    TimeSeries(freq=<Day>, transforms=['lag-7', 'lag-14', 'expanding_mean_lag-1', 'rolling_mean_lag-7_window_size-7', 'rolling_mean_lag-7_window_size-14'], date_features=['dayofweek', 'month'], num_threads=1)
 
 
 
@@ -106,7 +106,7 @@ fcst.fit(series)
 
 
 
-    Forecast(model=RandomForestRegressor(random_state=0), ts=TimeSeries(freq=<Day>, transforms=['lag-7', 'lag-14', 'expanding_mean_lag-1', 'rolling_mean_lag-7_window_size-7', 'rolling_mean_lag-7_window_size-14'], date_features=['dayofweek', 'month'], num_threads=8))
+    Forecast(model=RandomForestRegressor(random_state=0), ts=TimeSeries(freq=<Day>, transforms=['lag-7', 'lag-14', 'expanding_mean_lag-1', 'rolling_mean_lag-7_window_size-7', 'rolling_mean_lag-7_window_size-14'], date_features=['dayofweek', 'month'], num_threads=1))
 
 
 
@@ -181,8 +181,7 @@ series.to_parquet(data_path/'train')
 !mlforecast sample_configs/local.yaml
 ```
 
-    Split 1 MSE: 0.0251
-    Split 2 MSE: 0.0180
+    [0m
 
 ```python
 list((data_path/'outputs').iterdir())

--- a/action_files/black.sh
+++ b/action_files/black.sh
@@ -2,6 +2,7 @@
 # __all__ gets written by nbdev and formatting everytime is annoying
 # we just skip checking __all__ altogether
 for FILE in $(find mlforecast -name "[!_]*.py"); do
+  echo "Linting $FILE"
   START=$(grep -n "Cell" $FILE | head -n 1 | cut -d : -f 1)
   tail -n +$START $FILE | black --check -S - || exit -1
 done

--- a/docs/core.html
+++ b/docs/core.html
@@ -91,8 +91,7 @@ nb_path: "nbs/core.ipynb"
 <div class="output_area">
 
 
-<div class="output_html rendered_html output_subarea output_execute_result">
-<div>
+<div class="output_html rendered_html output_subarea output_execute_result"><div>
 <style scoped>
     .dataframe tbody tr th:only-of-type {
         vertical-align: middle;
@@ -204,8 +203,7 @@ nb_path: "nbs/core.ipynb"
   </tbody>
 </table>
 <p>4874 rows × 4 columns</p>
-</div>
-</div>
+</div></div>
 
 </div>
 
@@ -244,8 +242,7 @@ nb_path: "nbs/core.ipynb"
 <div class="output_area">
 
 
-<div class="output_html rendered_html output_subarea output_execute_result">
-<div>
+<div class="output_html rendered_html output_subarea output_execute_result"><div>
 <style scoped>
     .dataframe tbody tr th:only-of-type {
         vertical-align: middle;
@@ -357,8 +354,7 @@ nb_path: "nbs/core.ipynb"
   </tbody>
 </table>
 <p>222 rows × 4 columns</p>
-</div>
-</div>
+</div></div>
 
 </div>
 
@@ -436,7 +432,7 @@ nb_path: "nbs/core.ipynb"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h2 id="TimeSeries" class="doc_header"><code>class</code> <code>TimeSeries</code><a href="https://github.com/Nixtla/mlforecast/tree/main/mlforecast/core.py#L175" class="source_link" style="float:right">[source]</a></h2><blockquote><p><code>TimeSeries</code>(<strong><code>freq</code></strong>:<code>str</code>=<em><code>'D'</code></em>, <strong><code>lags</code></strong>:<code>List</code>[<code>int</code>]=<em><code>[]</code></em>, <strong><code>lag_transforms</code></strong>:<code>Dict</code>[<code>int</code>, <code>List</code>[<code>Tuple</code>]]=<em><code>{}</code></em>, <strong><code>date_features</code></strong>:<code>List</code>[<code>str</code>]=<em><code>[]</code></em>, <strong><code>num_threads</code></strong>:<code>int</code>=<em><code>1</code></em>)</p>
+<h2 id="TimeSeries" class="doc_header"><code>class</code> <code>TimeSeries</code><a href="https://github.com/Nixtla/mlforecast/tree/main/mlforecast/core.py#L175" class="source_link" style="float:right">[source]</a></h2><blockquote><p><code>TimeSeries</code>(<strong><code>freq</code></strong>:<code>str</code>=<em><code>'D'</code></em>, <strong><code>lags</code></strong>:<code>List</code>[<code>int</code>]=<em><code>[]</code></em>, <strong><code>lag_transforms</code></strong>:<code>Dict</code>[<code>int</code>, <code>typing.List[typing.Tuple]</code>]=<em><code>{}</code></em>, <strong><code>date_features</code></strong>:<code>List</code>[<code>str</code>]=<em><code>[]</code></em>, <strong><code>num_threads</code></strong>:<code>int</code>=<em><code>1</code></em>)</p>
 </blockquote>
 <p>Utility class for storing and transforming time series data.</p>
 
@@ -605,10 +601,10 @@ nb_path: "nbs/core.ipynb"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="TimeSeries.fit_transform" class="doc_header"><code>TimeSeries.fit_transform</code><a href="https://github.com/Nixtla/mlforecast/tree/main/mlforecast/core.py#L359" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>TimeSeries.fit_transform</code>(<strong><code>data</code></strong>:<code>DataFrame</code>, <strong><code>static_features</code></strong>:<code>Optional</code>[<code>List</code>[<code>str</code>]]=<em><code>None</code></em>, <strong><code>dropna</code></strong>:<code>bool</code>=<em><code>True</code></em>, <strong><code>keep_last_n</code></strong>:<code>Optional</code>[<code>int</code>]=<em><code>None</code></em>)</p>
+<h4 id="TimeSeries.fit_transform" class="doc_header"><code>TimeSeries.fit_transform</code><a href="https://github.com/Nixtla/mlforecast/tree/main/mlforecast/core.py#L351" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>TimeSeries.fit_transform</code>(<strong><code>data</code></strong>:<code>DataFrame</code>, <strong><code>static_features</code></strong>:<code>Optional</code>[<code>List</code>[<code>str</code>]]=<em><code>None</code></em>, <strong><code>dropna</code></strong>:<code>bool</code>=<em><code>True</code></em>, <strong><code>keep_last_n</code></strong>:<code>Optional</code>[<code>int</code>]=<em><code>None</code></em>)</p>
 </blockquote>
 <p>Add the features to <code>data</code> and save the required information for the predictions step.</p>
-<p>If not all features are static, specif which ones are in <code>static_features</code>.
+<p>If not all features are static, specify which ones are in <code>static_features</code>.
 If you don't want to drop rows with null values after the transformations set <code>dropna=False</code>.
 If you want to keep only the last <code>n</code> values of each time serie set <code>keep_last_n=n</code>.</p>
 
@@ -766,7 +762,10 @@ If you want to keep only the last <code>n</code> values of each time serie set <
     <div class="input_area">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="n">ts</span><span class="o">.</span><span class="n">fit_transform</span><span class="p">(</span><span class="n">series</span><span class="p">,</span> <span class="n">static_features</span><span class="o">=</span><span class="p">[</span><span class="s1">&#39;static_0&#39;</span><span class="p">])</span>
 
-<span class="k">assert</span> <span class="n">ts</span><span class="o">.</span><span class="n">static_features</span><span class="o">.</span><span class="n">equals</span><span class="p">(</span><span class="n">series</span><span class="o">.</span><span class="n">groupby</span><span class="p">(</span><span class="s1">&#39;unique_id&#39;</span><span class="p">)</span><span class="o">.</span><span class="n">tail</span><span class="p">(</span><span class="mi">1</span><span class="p">)[[</span><span class="s1">&#39;static_0&#39;</span><span class="p">]])</span>
+<span class="n">pd</span><span class="o">.</span><span class="n">testing</span><span class="o">.</span><span class="n">assert_frame_equal</span><span class="p">(</span>
+    <span class="n">ts</span><span class="o">.</span><span class="n">static_features</span><span class="p">,</span>
+    <span class="n">series</span><span class="o">.</span><span class="n">groupby</span><span class="p">(</span><span class="s1">&#39;unique_id&#39;</span><span class="p">)</span><span class="o">.</span><span class="n">tail</span><span class="p">(</span><span class="mi">1</span><span class="p">)[[</span><span class="s1">&#39;static_0&#39;</span><span class="p">]],</span>
+<span class="p">)</span>
 </pre></div>
 
     </div>
@@ -900,7 +899,7 @@ If you want to keep only the last <code>n</code> values of each time serie set <
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="TimeSeries.predict" class="doc_header"><code>TimeSeries.predict</code><a href="https://github.com/Nixtla/mlforecast/tree/main/mlforecast/core.py#L392" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>TimeSeries.predict</code>(<strong><code>model</code></strong>, <strong><code>horizon</code></strong>:<code>int</code>, <strong><code>dynamic_dfs</code></strong>:<code>Optional</code>[<code>List</code>[<code>DataFrame</code>]]=<em><code>None</code></em>, <strong><code>predict_fn</code></strong>:<code>Optional</code>[<code>Callable</code>]=<em><code>None</code></em>, <strong>**<code>predict_fn_kwargs</code></strong>)</p>
+<h4 id="TimeSeries.predict" class="doc_header"><code>TimeSeries.predict</code><a href="https://github.com/Nixtla/mlforecast/tree/main/mlforecast/core.py#L396" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>TimeSeries.predict</code>(<strong><code>model</code></strong>, <strong><code>horizon</code></strong>:<code>int</code>, <strong><code>dynamic_dfs</code></strong>:<code>Optional</code>[<code>List</code>[<code>DataFrame</code>]]=<em><code>None</code></em>, <strong><code>predict_fn</code></strong>:<code>Optional</code>[<code>typing.Callable</code>]=<em><code>None</code></em>, <strong>**<code>predict_fn_kwargs</code></strong>)</p>
 </blockquote>
 <p>Use <code>model</code> to predict the next <code>horizon</code> timesteps.</p>
 
@@ -1003,5 +1002,5 @@ If you want to keep only the last <code>n</code> values of each time serie set <
     {% endraw %}
 
 </div>
- 
+
 

--- a/mlforecast/cli.py
+++ b/mlforecast/cli.py
@@ -30,7 +30,7 @@ def run_forecast(config_file: str):
     if config.distributed is not None:  # mypy
         client = setup_client(config.distributed.cluster)
     else:
-        client = None
+        client = None  # type: ignore
     try:
         data = read_data(config.data, is_distributed)
         dynamic_dfs = _read_dynamic(config.data)

--- a/mlforecast/compat.py
+++ b/mlforecast/compat.py
@@ -18,7 +18,7 @@ except ImportError:
     class dd:  # type: ignore
         pass
 
-    dd_Frame = type(None)
+    dd_Frame = type(None)  # type: ignore
 
     class Client:  # type: ignore
         pass

--- a/mlforecast/core.py
+++ b/mlforecast/core.py
@@ -15,7 +15,7 @@ import pandas as pd
 from numba import njit
 from window_ops.shift import shift_array
 
-from .utils import data_indptr_from_sorted_df, ensure_sorted
+from .utils import data_indptr_from_sorted_df
 
 # Internal Cell
 date_features_dtypes = {
@@ -362,16 +362,15 @@ class TimeSeries:
         If you want to keep only the last `n` values of each time serie set `keep_last_n=n`.
         """
         if data.index.name != 'unique_id' or 'ds' not in data or 'y' not in data:
-            raise ValueError('data must have an index named unique_id and ds and y columns.')
+            raise ValueError(
+                'data must have an index named unique_id and ds and y columns.'
+            )
         if data['y'].isnull().any():
             raise ValueError('y column contains null values.')
         if static_features is None:
             static_features = data.columns.drop(['ds', 'y'])
         self.static_features = (
-            data[static_features]
-            .reset_index()
-            .drop_duplicates()
-            .set_index('unique_id')
+            data[static_features].reset_index().drop_duplicates().set_index('unique_id')
         )
         sort_idxs = pd.core.sorting.lexsort_indexer([data.index, data['ds']])
         sorted_data = data[['ds', 'y']].set_index('ds', append=True).iloc[sort_idxs]

--- a/mlforecast/distributed/forecast.py
+++ b/mlforecast/distributed/forecast.py
@@ -81,7 +81,7 @@ class DistributedForecast:
         dropna: bool = True,
         keep_last_n: Optional[int] = None,
         dynamic_dfs: Optional[List[pd.DataFrame]] = None,
-        predict_fn: Callable = simple_predict,
+        predict_fn: Callable = None,
         **predict_fn_kwargs,
     ) -> Generator[dd.DataFrame, None, None]:
         """Creates `n_windows` splits of `window_size` from `data`, trains the model

--- a/mlforecast/distributed/forecast.py
+++ b/mlforecast/distributed/forecast.py
@@ -9,7 +9,7 @@ import dask.dataframe as dd
 import pandas as pd
 from dask.distributed import Client, default_client
 
-from ..core import TimeSeries, simple_predict
+from ..core import TimeSeries
 from ..utils import backtest_splits
 from .core import DistributedTimeSeries
 

--- a/nbs/api.ipynb
+++ b/nbs/api.ipynb
@@ -623,18 +623,6 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/nbs/cli.ipynb
+++ b/nbs/cli.ipynb
@@ -140,6 +140,7 @@
     "#hide\n",
     "series = generate_daily_series(20, 100, 200, n_static_features=5, equal_ends=True)\n",
     "series = series.rename(columns={'static_1': 'product_id'})\n",
+    "static_features = series.columns.drop(['ds', 'y']).tolist()\n",
     "prices = generate_prices_for_series(series)\n",
     "\n",
     "config_name = 'local.yaml'\n",
@@ -161,6 +162,7 @@
     "                writer = getattr(prices, f'to_{data_format}')\n",
     "                writer(tmpdir / 'prices', index=False)\n",
     "                cfg['data']['dynamic'] = ['prices']\n",
+    "                cfg['features']['static_features'] = static_features\n",
     "            with open(config_path, 'wt') as f:\n",
     "                yaml.dump(cfg, f)\n",
     "            run_forecast(config_path)"
@@ -211,7 +213,8 @@
     "        if with_prices:\n",
     "            writer = getattr(prices_df, f'to_{data_format}')\n",
     "            writer(tmpdir / 'prices', index=False)\n",
-    "            cfg['data']['dynamic'] = ['prices']            \n",
+    "            cfg['data']['dynamic'] = ['prices']\n",
+    "            cfg['features']['static_features'] = static_features\n",
     "        with open(config_path, 'wt') as f:\n",
     "            yaml.dump(cfg, f)\n",
     "        run_forecast(config_path)    \n",
@@ -497,18 +500,6 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/nbs/cli.ipynb
+++ b/nbs/cli.ipynb
@@ -71,7 +71,7 @@
     "    if config.distributed is not None:  # mypy\n",
     "        client = setup_client(config.distributed.cluster)\n",
     "    else:\n",
-    "        client = None\n",
+    "        client = None  # type: ignore\n",
     "    try:\n",
     "        data = read_data(config.data, is_distributed)\n",
     "        dynamic_dfs = _read_dynamic(config.data)\n",

--- a/nbs/compat.ipynb
+++ b/nbs/compat.ipynb
@@ -33,7 +33,7 @@
     "    class dd:  # type: ignore\n",
     "        pass\n",
     "\n",
-    "    dd_Frame = type(None)\n",
+    "    dd_Frame = type(None)  # type: ignore\n",
     "\n",
     "    class Client:  # type: ignore\n",
     "        pass\n",
@@ -67,7 +67,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   }

--- a/nbs/core.ipynb
+++ b/nbs/core.ipynb
@@ -507,23 +507,15 @@
     "        )\n",
     "        return df\n",
     "    \n",
-    "    def _fit(\n",
-    "        self,\n",
-    "        df: pd.DataFrame,\n",
-    "        static_features: Optional[List[str]] = None,\n",
-    "    ) -> 'TimeSeries':\n",
-    "        \"\"\"Save the series values, ids, last dates and static features.\"\"\"\n",
+    "    def _fit(self, df: pd.DataFrame) -> 'TimeSeries':\n",
+    "        \"\"\"Save the series values, ids and last dates.\"\"\"\n",
     "        data, indptr = data_indptr_from_sorted_df(df)\n",
     "        if data.dtype not in (np.float32, np.float64):\n",
     "            # since all transformations generate nulls, we need a float dtype\n",
     "            data = data.astype(np.float32)\n",
     "        self.ga = GroupedArray(data, indptr)\n",
     "        self.uids = df.index.unique(level='unique_id')\n",
-    "        last_obs = df.iloc[indptr[1:] - 1]\n",
-    "        self.last_dates = last_obs.index.get_level_values('ds')\n",
-    "        self.static_features = last_obs.reset_index('ds').drop(columns=['ds', 'y'])\n",
-    "        if static_features is not None:\n",
-    "            self.static_features = self.static_features[static_features]\n",
+    "        self.last_dates = df.index.get_level_values('ds')[indptr[1:] - 1]\n",
     "        return self\n",
     "\n",
     "    def _transform(\n",
@@ -536,10 +528,10 @@
     "        \n",
     "        if `dropna=True` then all the null rows are dropped.\n",
     "        if `keep_last_n` is not None then that number of observations is kept across all series.\"\"\"\n",
-    "        df = df.reset_index('ds')\n",
+    "        df = df.copy()\n",
     "        features = self._compute_transforms()\n",
     "        for feat in self.transforms.keys():\n",
-    "            df[feat] = features[feat]\n",
+    "            df[feat] = features[feat][self.restore_idxs]\n",
     "\n",
     "        if dropna:\n",
     "            df.dropna(inplace=True)\n",
@@ -564,15 +556,27 @@
     "    ) -> pd.DataFrame:\n",
     "        \"\"\"Add the features to `data` and save the required information for the predictions step.\n",
     "        \n",
-    "        If not all features are static, specif which ones are in `static_features`.\n",
+    "        If not all features are static, specify which ones are in `static_features`.\n",
     "        If you don't want to drop rows with null values after the transformations set `dropna=False`.\n",
     "        If you want to keep only the last `n` values of each time serie set `keep_last_n=n`.\n",
     "        \"\"\"\n",
+    "        if data.index.name != 'unique_id' or 'ds' not in data or 'y' not in data:\n",
+    "            raise ValueError('data must have an index named unique_id and ds and y columns.')\n",
     "        if data['y'].isnull().any():\n",
     "            raise ValueError('y column contains null values.')\n",
-    "        data = ensure_sorted(data)\n",
-    "        data = data.set_index('ds', append=True)\n",
-    "        self._fit(data, static_features)\n",
+    "        if static_features is None:\n",
+    "            static_features = data.columns.drop(['ds', 'y'])\n",
+    "        self.static_features = (\n",
+    "            data[static_features]\n",
+    "            .reset_index()\n",
+    "            .drop_duplicates()\n",
+    "            .set_index('unique_id')\n",
+    "        )\n",
+    "        sort_idxs = pd.core.sorting.lexsort_indexer([data.index, data['ds']])        \n",
+    "        sorted_data = data[['ds', 'y']].set_index('ds', append=True).iloc[sort_idxs]\n",
+    "        self.restore_idxs = np.empty(data.shape[0], dtype=np.int32)\n",
+    "        self.restore_idxs[sort_idxs] = np.arange(data.shape[0])\n",
+    "        self._fit(sorted_data)\n",
     "        return self._transform(data, dropna, keep_last_n)\n",
     "    \n",
     "    def _predict_setup(self) -> None:\n",
@@ -708,21 +712,11 @@
    "outputs": [],
    "source": [
     "#hide\n",
-    "serie = serie.set_index('ds', append=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#hide\n",
     "# int y is converted to float32\n",
     "serie2 = serie.copy()\n",
     "serie2['y'] = serie2['y'].astype(int)\n",
     "ts = TimeSeries(num_threads=1)\n",
-    "ts._fit(serie2)\n",
+    "ts._fit(serie2.set_index('ds', append=True))\n",
     "test_eq(ts.ga.data.dtype, np.float32)"
    ]
   },
@@ -739,7 +733,7 @@
     "\n",
     "for num_threads in (1, 2):\n",
     "    ts = TimeSeries(**flow_config)\n",
-    "    ts._fit(serie)\n",
+    "    ts._fit(serie.set_index('ds', append=True))\n",
     "    transforms = ts._compute_transforms()\n",
     "\n",
     "    np.testing.assert_equal(transforms['lag-7'], shift_array(y, 7))\n",
@@ -756,7 +750,7 @@
     "#hide\n",
     "# update_y\n",
     "ts = TimeSeries()\n",
-    "ts._fit(serie)\n",
+    "ts._fit(serie.set_index('ds', append=True))\n",
     "max_size = np.diff(ts.ga.indptr)\n",
     "ts._update_y([1])\n",
     "ts._update_y([2])\n",
@@ -774,10 +768,10 @@
     "#hide\n",
     "# _update_features\n",
     "ts = TimeSeries(**flow_config)\n",
-    "ts._fit(serie)\n",
+    "ts.fit_transform(serie)\n",
     "updates = ts._update_features().drop(columns='ds')\n",
     "\n",
-    "last_date = serie.index.get_level_values('ds').max()\n",
+    "last_date = serie['ds'].max()\n",
     "first_prediction_date = last_date + ts.freq\n",
     "expected_idx = pd.Index(ts.uids, name='unique_id')\n",
     "\n",
@@ -789,7 +783,7 @@
     "    'dayofweek': np.uint8([getattr(first_prediction_date, 'dayofweek')])},\n",
     "    index=expected_idx\n",
     ")\n",
-    "statics = serie.tail(1).reset_index('ds').drop(columns=['ds', 'y'])\n",
+    "statics = serie.tail(1).drop(columns=['ds', 'y'])\n",
     "assert updates.equals(statics.join(expected))\n",
     "\n",
     "test_eq(ts.curr_dates[0], first_prediction_date)"
@@ -804,26 +798,16 @@
     "#hide\n",
     "# _get_predictions\n",
     "ts = TimeSeries()\n",
-    "ts._fit(serie)\n",
+    "ts.fit_transform(serie)\n",
     "ts._update_features()\n",
     "ts._update_y([1.])\n",
     "preds = ts._get_predictions()\n",
     "\n",
-    "last_ds = serie.index.get_level_values('ds').max()\n",
+    "last_ds = serie['ds'].max()\n",
     "expected_idx = serie.index.get_level_values('unique_id')[[0]]\n",
     "expected = pd.DataFrame({'ds': [last_ds + ts.freq], 'y_pred': [1.]},\n",
     "                        index=expected_idx)\n",
     "assert preds.equals(expected)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#hide\n",
-    "serie = serie.reset_index('ds')"
    ]
   },
   {
@@ -938,7 +922,10 @@
    "source": [
     "ts.fit_transform(series, static_features=['static_0'])\n",
     "\n",
-    "assert ts.static_features.equals(series.groupby('unique_id').tail(1)[['static_0']])"
+    "pd.testing.assert_frame_equal(\n",
+    "    ts.static_features,\n",
+    "    series.groupby('unique_id').tail(1)[['static_0']],\n",
+    ")"
    ]
   },
   {
@@ -1027,10 +1014,10 @@
     "# unsorted df\n",
     "ts = TimeSeries(**flow_config)\n",
     "df = ts.fit_transform(series)\n",
-    "unordered_series = series.sample(frac=1.)\n",
+    "unordered_series = series.sample(frac=1.0)\n",
     "assert not unordered_series.set_index('ds', append=True).index.is_monotonic_increasing\n",
     "df2 = ts.fit_transform(unordered_series)\n",
-    "pd.testing.assert_frame_equal(df, df2)"
+    "pd.testing.assert_frame_equal(df, df2.sort_values(['unique_id', 'ds']))"
    ]
   },
   {
@@ -1117,7 +1104,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   }

--- a/nbs/core.ipynb
+++ b/nbs/core.ipynb
@@ -46,7 +46,7 @@
     "from numba import njit\n",
     "from window_ops.shift import shift_array\n",
     "\n",
-    "from mlforecast.utils import data_indptr_from_sorted_df, ensure_sorted"
+    "from mlforecast.utils import data_indptr_from_sorted_df"
    ]
   },
   {
@@ -561,16 +561,15 @@
     "        If you want to keep only the last `n` values of each time serie set `keep_last_n=n`.\n",
     "        \"\"\"\n",
     "        if data.index.name != 'unique_id' or 'ds' not in data or 'y' not in data:\n",
-    "            raise ValueError('data must have an index named unique_id and ds and y columns.')\n",
+    "            raise ValueError(\n",
+    "                'data must have an index named unique_id and ds and y columns.'\n",
+    "            )\n",
     "        if data['y'].isnull().any():\n",
     "            raise ValueError('y column contains null values.')\n",
     "        if static_features is None:\n",
     "            static_features = data.columns.drop(['ds', 'y'])\n",
     "        self.static_features = (\n",
-    "            data[static_features]\n",
-    "            .reset_index()\n",
-    "            .drop_duplicates()\n",
-    "            .set_index('unique_id')\n",
+    "            data[static_features].reset_index().drop_duplicates().set_index('unique_id')\n",
     "        )\n",
     "        sort_idxs = pd.core.sorting.lexsort_indexer([data.index, data['ds']])        \n",
     "        sorted_data = data[['ds', 'y']].set_index('ds', append=True).iloc[sort_idxs]\n",

--- a/nbs/distributed.forecast.ipynb
+++ b/nbs/distributed.forecast.ipynb
@@ -70,7 +70,7 @@
     "import pandas as pd\n",
     "from dask.distributed import Client, default_client\n",
     "\n",
-    "from mlforecast.core import TimeSeries, simple_predict\n",
+    "from mlforecast.core import TimeSeries\n",
     "from mlforecast.utils import backtest_splits\n",
     "from mlforecast.distributed.core import DistributedTimeSeries\n"
    ]

--- a/nbs/distributed.forecast.ipynb
+++ b/nbs/distributed.forecast.ipynb
@@ -149,7 +149,7 @@
     "        dropna: bool = True,\n",
     "        keep_last_n: Optional[int] = None,\n",
     "        dynamic_dfs: Optional[List[pd.DataFrame]] = None,\n",
-    "        predict_fn: Callable = simple_predict,\n",
+    "        predict_fn: Callable = None,\n",
     "        **predict_fn_kwargs,\n",
     "    ) -> Generator[dd.DataFrame, None, None]:\n",
     "        \"\"\"Creates `n_windows` splits of `window_size` from `data`, trains the model\n",
@@ -858,7 +858,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   }


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please make sure to provide a meaningful description and let us know that you've completed all the requirements in the checklist by marking them with an x.
-->

## Description
<!-- What this PR does. If this work is related to a specific issue please reference it here. -->
Since the input for the transformations has to be sorted we used to sort the whole dataframe, however this can be very inefficient when there are many dynamic columns. This PR sorts using only the `ds` and `y` columns before constructing the `GroupedArray` thus keeping the peak memory usage constant with respect to the number of dynamic features.

Checklist:
- [x] This PR has a meaningful title and a clear description.
- [x] The tests pass.
- [ ] There isn't a decrease in the tests coverage.
- [x] All linting tasks pass.
- [x] The notebooks are clean.
- [x] If this modifies the docs, you've made sure that they were updated correctly.