### PR TITLE
[FEAT] Allow used by GitHub section hardcoding lib name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ min_python = cfg['min_python']
 lic = licenses.get(cfg['license'].lower(), (cfg['license'], None))
 
 setuptools.setup(
-    name = cfg['lib_name'],
+    name = 'mlforecast', 
     license = lic[0],
     classifiers = [
         'Development Status :: ' + statuses[int(cfg['status'])],


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please make sure to provide a meaningful description and let us know that you've completed all the requirements in the checklist by marking them with an x.
-->

## Description
<!-- What this PR does. If this work is related to a specific issue please reference it here. -->

By default, `nbdev` sets the library name in the `setup.py` file using `settings.ini` but prevents GitHub from finding dependent libraries (`Used By` section). Hardcoding the library name in `setup.py` solves the problem.

Checklist:
- [x] This PR has a meaningful title and a clear description.
- [x] The tests pass.
- [x] All linting tasks pass.
- [x] The notebooks are clean.
