### PR TITLE
copy target col before replacing on transform

### DIFF
--- a/mlforecast/core.py
+++ b/mlforecast/core.py
@@ -415,6 +415,7 @@ class TimeSeries:
             df[feat] = self.features_[feat][self.restore_idxs]
 
         if self.differences:
+            df[self.target_col] = df[self.target_col].copy()
             df[self.target_col] = self.ga.data[self.restore_idxs]
 
         if dropna:

--- a/nbs/core.ipynb
+++ b/nbs/core.ipynb
@@ -933,6 +933,7 @@
     "            df[feat] = self.features_[feat][self.restore_idxs]\n",
     "\n",
     "        if self.differences:\n",
+    "            df[self.target_col] = df[self.target_col].copy()\n",
     "            df[self.target_col] = self.ga.data[self.restore_idxs]            \n",
     "            \n",
     "        if dropna:\n",


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please make sure to provide a meaningful description and let us know that you've completed all the requirements in the checklist by marking them with an x.
-->

## Description
<!-- What this PR does. If this work is related to a specific issue please reference it here. -->
Since in the transform step we do `df.copy(deep=False)` we share the arrays of the original dataframe, this is mostly fine since we used to only add columns but with the differences introduced in #52 the original array was modified. This makes a copy first.

Checklist:
- [x] This PR has a meaningful title and a clear description.
- [x] The tests pass.
- [x] All linting tasks pass.
- [x] The notebooks are clean.