### PR TITLE
[FEAT] Ignore jupyter notebooks as part of `languages`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+nbs/** linguist-documentation


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please make sure to provide a meaningful description and let us know that you've completed all the requirements in the checklist by marking them with an x.
-->

## Description
<!-- What this PR does. If this work is related to a specific issue please reference it here. -->

This PR allows to ignore jupyter notebooks in the language part of the repo:

<img width="349" alt="image" src="https://user-images.githubusercontent.com/10517170/205808917-cd7861e3-b3c6-40a1-8849-4b8096e50ea1.png">

Before the change, the language stats were,

<img width="410" alt="image" src="https://user-images.githubusercontent.com/10517170/205808853-67497a32-2f45-4b4c-a2d8-af347dfae277.png">


After the change,

<img width="548" alt="image" src="https://user-images.githubusercontent.com/10517170/205808815-c87b43d3-4d03-4c09-b052-da088a664e20.png">



Checklist:
- [x] This PR has a meaningful title and a clear description.
- [ ] The tests pass.
- [ ] All linting tasks pass.
- [x] The notebooks are clean.