### PR TITLE
set encoding on README open

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setuptools.setup(
     },
     dependency_links = cfg.get('dep_links','').split(),
     python_requires  = '>=' + cfg['min_python'],
-    long_description = open('README.md').read(),
+    long_description = open('README.md', encoding='utf-8').read(),
     long_description_content_type = 'text/markdown',
     zip_safe = False,
     entry_points = { 'console_scripts': cfg.get('console_scripts','').split() },


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please make sure to provide a meaningful description and let us know that you've completed all the requirements in the checklist by marking them with an x.
-->

## Description
<!-- What this PR does. If this work is related to a specific issue please reference it here. -->
Fixes an error in the setup on windows caused by opening the README file without specifying the encoding.

Checklist:
- [x] This PR has a meaningful title and a clear description.
- [x] The tests pass.
- [x] All linting tasks pass.
- [x] The notebooks are clean.