### PR TITLE
set lower bound on spark for tests

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - pandas
   - pip
   - pylint
-  - pyspark
+  - pyspark>=3.3
   - scikit-learn
   - window-ops
   - xgboost


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please make sure to provide a meaningful description and let us know that you've completed all the requirements in the checklist by marking them with an x.
-->

## Description
<!-- What this PR does. If this work is related to a specific issue please reference it here. -->
Fixes the tests for python3.7 that were failing because they were getting an older version of spark (2.4)

Checklist:
- [x] This PR has a meaningful title and a clear description.
- [x] The tests pass.
- [x] All linting tasks pass.
- [x] The notebooks are clean.