### PR TITLE
raise error for wrong frequency in cross_validation

### DIFF
--- a/mlforecast/forecast.py
+++ b/mlforecast/forecast.py
@@ -624,6 +624,11 @@ class MLForecast:
             result = valid[[id_col, time_col, target_col]].merge(
                 y_pred, on=[id_col, time_col]
             )
+            if result.shape[0] < valid.shape[0]:
+                raise ValueError(
+                    "Cross validation result produced empty dataframe. "
+                    "Please verify that the frequency set on the MLForecast constructor matches your series."
+                )
             results.append(result)
         out = pd.concat(results)
         cols_order = [id_col, time_col, "cutoff", target_col]

--- a/mlforecast/forecast.py
+++ b/mlforecast/forecast.py
@@ -626,8 +626,9 @@ class MLForecast:
             )
             if result.shape[0] < valid.shape[0]:
                 raise ValueError(
-                    "Cross validation result produced empty dataframe. "
-                    "Please verify that the frequency set on the MLForecast constructor matches your series."
+                    "Cross validation result produced less results than expected. "
+                    "Please verify that the frequency set on the MLForecast constructor matches your series' "
+                    "and that there aren't any missing periods."
                 )
             results.append(result)
         out = pd.concat(results)

--- a/nbs/forecast.ipynb
+++ b/nbs/forecast.ipynb
@@ -708,6 +708,11 @@
     "            )\n",
     "            y_pred = y_pred.merge(cutoffs, on=id_col, how='left')\n",
     "            result = valid[[id_col, time_col, target_col]].merge(y_pred, on=[id_col, time_col])\n",
+    "            if result.shape[0] < valid.shape[0]:\n",
+    "                raise ValueError(\n",
+    "                    'Cross validation result produced empty dataframe. '\n",
+    "                    'Please verify that the frequency set on the MLForecast constructor matches your series.'\n",
+    "                )\n",
     "            results.append(result)\n",
     "        out = pd.concat(results)\n",
     "        cols_order = [id_col, time_col, 'cutoff', target_col]\n",
@@ -2972,6 +2977,31 @@
     ")\n",
     "# the rest is different\n",
     "test_fail(lambda: pd.testing.assert_frame_equal(cv_results_intervals, cv_results2_intervals))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6234482e-1e43-4168-88d2-0c06ba06b7bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#| hide\n",
+    "# wrong frequency raises error\n",
+    "from sklearn.linear_model import LinearRegression\n",
+    "\n",
+    "df_wrong_freq = pd.DataFrame({'ds': pd.to_datetime(['2020-01-02', '2020-02-02', '2020-03-02', '2020-04-02'])})\n",
+    "df_wrong_freq['unique_id'] = 'id1'\n",
+    "df_wrong_freq['y'] = 1\n",
+    "fcst_wrong_freq = MLForecast(\n",
+    "    models=[LinearRegression()],\n",
+    "    freq='MS',\n",
+    "    lags=[1],\n",
+    ")\n",
+    "test_fail(\n",
+    "    lambda: fcst_wrong_freq.cross_validation(df_wrong_freq, n_windows=1, window_size=1),\n",
+    "    contains='Cross validation result produced empty dataframe',\n",
+    ")"
    ]
   },
   {

--- a/nbs/forecast.ipynb
+++ b/nbs/forecast.ipynb
@@ -710,8 +710,9 @@
     "            result = valid[[id_col, time_col, target_col]].merge(y_pred, on=[id_col, time_col])\n",
     "            if result.shape[0] < valid.shape[0]:\n",
     "                raise ValueError(\n",
-    "                    'Cross validation result produced empty dataframe. '\n",
-    "                    'Please verify that the frequency set on the MLForecast constructor matches your series.'\n",
+    "                    \"Cross validation result produced less results than expected. \"\n",
+    "                    \"Please verify that the frequency set on the MLForecast constructor matches your series' \"\n",
+    "                    \"and that there aren't any missing periods.\"\n",
     "                )\n",
     "            results.append(result)\n",
     "        out = pd.concat(results)\n",
@@ -3000,7 +3001,7 @@
     ")\n",
     "test_fail(\n",
     "    lambda: fcst_wrong_freq.cross_validation(df_wrong_freq, n_windows=1, window_size=1),\n",
-    "    contains='Cross validation result produced empty dataframe',\n",
+    "    contains='Cross validation result produced less results than expected',\n",
     ")"
    ]
   },


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please make sure to provide a meaningful description and let us know that you've completed all the requirements in the checklist by marking them with an x.
-->

## Description
<!-- What this PR does. If this work is related to a specific issue please reference it here. -->
The cross validation performs an inner join between the predictions and the validation set by the id_col and the time_col. If a wrong frequency is set it's possible that this join produces an empty result or drops predictions for periods where the data wasn't observed. The behavior right now is that this can produce an error when attempting to compute prediction intervals, this PR changes it so that a more informative error is raised when the inner join drops one or more rows.

Fixes #159

Checklist:
- [x] This PR has a meaningful title and a clear description.
- [x] The tests pass.
- [x] All linting tasks pass.
- [x] The notebooks are clean.