### PR TITLE
fix TimeSeries.update method

### DIFF
--- a/mlforecast/core.py
+++ b/mlforecast/core.py
@@ -596,9 +596,8 @@ class TimeSeries:
         )
         self.static_features_.update(new_statics)
         self.static_features_ = self.static_features_.reset_index().astype(orig_dtypes)
-        self.ga = self.ga.append_several(
+        self._ga = self._ga.append_several(
             new_sizes=sizes.values.astype(np.int32),
             new_values=values,
             new_groups=new_groups,
         )
-        self._ga = GroupedArray(self.ga.data, self.ga.indptr)

--- a/nbs/core.ipynb
+++ b/nbs/core.ipynb
@@ -1039,12 +1039,11 @@
     "        self.static_features_ = self.static_features_.set_index(self.id_col).reindex(self.uids)\n",
     "        self.static_features_.update(new_statics)\n",
     "        self.static_features_ = self.static_features_.reset_index().astype(orig_dtypes)\n",
-    "        self.ga = self.ga.append_several(\n",
+    "        self._ga = self._ga.append_several(\n",
     "            new_sizes=sizes.values.astype(np.int32),\n",
     "            new_values=values,\n",
     "            new_groups=new_groups,\n",
-    "        )\n",
-    "        self._ga = GroupedArray(self.ga.data, self.ga.indptr)"
+    "        )"
    ]
   },
   {
@@ -1770,6 +1769,10 @@
    "outputs": [],
    "source": [
     "#| hide\n",
+    "class ZerosModel:\n",
+    "    def predict(self, X):\n",
+    "        return np.full(X.shape[0], 0)\n",
+    "\n",
     "class NaiveModel:\n",
     "    def predict(self, X: pd.DataFrame):\n",
     "        return X['lag1']\n",
@@ -1782,6 +1785,7 @@
     "    time_col='ds',\n",
     "    target_col='y',\n",
     ")\n",
+    "ts.predict({'zero': ZerosModel()}, 4)\n",
     "last_vals_two_series = two_series.groupby('unique_id').tail(1)\n",
     "last_val_id0 = last_vals_two_series[lambda x: x['unique_id'].eq('id_00')].copy()\n",
     "new_values = last_val_id0.copy()\n",


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please make sure to provide a meaningful description and let us know that you've completed all the requirements in the checklist by marking them with an x.
-->

## Description
<!-- What this PR does. If this work is related to a specific issue please reference it here. -->
Fixes a bug introduced in #171 where the update method would use previously computed predictions instead of the actual target.

Checklist:
- [x] This PR has a meaningful title and a clear description.
- [x] The tests pass.
- [x] All linting tasks pass.
- [x] The notebooks are clean.