### PR TITLE
fix static_features order

### DIFF
--- a/mlforecast/core.py
+++ b/mlforecast/core.py
@@ -235,6 +235,7 @@ class TimeSeries:
             df[static_features]
             .groupby(id_col, observed=True)
             .head(1)
+            .sort_values(id_col)
             .reset_index(drop=True)
         )
         sort_idxs = pd.core.sorting.lexsort_indexer([df[id_col], df[time_col]])

--- a/nbs/core.ipynb
+++ b/nbs/core.ipynb
@@ -686,6 +686,7 @@
     "            [static_features]\n",
     "            .groupby(id_col, observed=True)\n",
     "            .head(1)\n",
+    "            .sort_values(id_col)            \n",
     "            .reset_index(drop=True)\n",
     "        )\n",
     "        sort_idxs = pd.core.sorting.lexsort_indexer([df[id_col], df[time_col]])\n",


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please make sure to provide a meaningful description and let us know that you've completed all the requirements in the checklist by marking them with an x.
-->

## Description
<!-- What this PR does. If this work is related to a specific issue please reference it here. -->
Fixes a bug where `TimeSeries.static_features_` were assumed to be sorted by id and it wasn't always the case.

Checklist:
- [x] This PR has a meaningful title and a clear description.
- [x] The tests pass.
- [x] All linting tasks pass.
- [x] The notebooks are clean.