### PR TITLE
align ends when inverting transformations for max_horizon

### DIFF
--- a/nbs/forecast.ipynb
+++ b/nbs/forecast.ipynb
@@ -428,10 +428,6 @@
     "            return df\n",
     "        for tfm in self.ts.target_transforms[::-1]:\n",
     "            df = tfm.inverse_transform(df)\n",
-    "            if hasattr(tfm, 'store_fitted'):\n",
-    "                tfm.store_fitted = False\n",
-    "            if hasattr(tfm, 'fitted_'):\n",
-    "                tfm.fitted_ = []\n",
     "        return df\n",
     "\n",
     "    def _compute_fitted_values(\n",
@@ -472,10 +468,17 @@
     "                    horizon_fitted_values[horizon][name] = model.predict(X)\n",
     "            for horizon, horizon_df in enumerate(horizon_fitted_values):\n",
     "                keep_mask = horizon_df[target_col].notnull()\n",
+    "                horizon_df = horizon_df[keep_mask].copy()\n",
     "                horizon_df = self._invert_transforms(horizon_df)\n",
-    "                horizon_df['h'] = horizon + 1\n",
-    "                horizon_fitted_values[horizon] = horizon_df[keep_mask].copy()\n",
+    "                horizon_df[\"h\"] = horizon + 1\n",
+    "                horizon_fitted_values[horizon] = horizon_df\n",
     "            fitted_values = pd.concat(horizon_fitted_values)\n",
+    "        if self.ts.target_transforms is not None:\n",
+    "            for tfm in self.ts.target_transforms[::-1]:            \n",
+    "                if hasattr(tfm, 'store_fitted'):\n",
+    "                    tfm.store_fitted = False\n",
+    "                if hasattr(tfm, 'fitted_'):\n",
+    "                    tfm.fitted_ = []            \n",
     "        return fitted_values\n",
     "\n",
     "    @old_kw_to_pos(['data'], [1])\n",
@@ -1338,7 +1341,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fcst.fit(train, fitted=True, dropna=True);"
+    "fcst.fit(train, fitted=True);"
    ]
   },
   {
@@ -1380,7 +1383,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89ea6504-5fd9-4ae1-ad06-127ca0147943",
+   "id": "e783e194-3527-4027-8308-9201d3c9783e",
    "metadata": {},
    "outputs": [
     {
@@ -1560,7 +1563,18 @@
     "pd.testing.assert_frame_equal(\n",
     "    fcst.forecast_fitted_values().reset_index(drop=True),\n",
     "    max_horizon_fitted_values[max_horizon_fitted_values['h'] == 1].drop(columns='h'),\n",
-    ");"
+    ")\n",
+    "# restored values match\n",
+    "xx = max_horizon_fitted_values[lambda x: x['unique_id'].eq('H413')].pivot_table(\n",
+    "    index=['unique_id', 'ds'], columns='h', values='y'\n",
+    ").loc['H413']\n",
+    "first_ds = xx.index.min()\n",
+    "last_ds = xx.index.max()\n",
+    "for h in range(1, max_horizon):\n",
+    "    np.testing.assert_allclose(\n",
+    "        xx.loc[first_ds + h :, 1].values,\n",
+    "        xx.loc[: last_ds - h, h + 1].values,\n",
+    "    )"
    ]
   },
   {


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please make sure to provide a meaningful description and let us know that you've completed all the requirements in the checklist by marking them with an x.
-->

## Description
<!-- What this PR does. If this work is related to a specific issue please reference it here. -->
When using `max_horizon` the targets are offset, so for the first date the target at horizon 1 is the value at that date, however for the horizon 2 the target is the value at the second date and so on. The differences inverse transformation for the fitted values assumes that the serie that we're inverse transforming ends at the same period as the original one. This PR ensures that this transformation is done correctly.

Checklist:
- [x] This PR has a meaningful title and a clear description.
- [x] The tests pass.
- [x] All linting tasks pass.
- [x] The notebooks are clean.