### PR TITLE
ensure lags are positive integers

### DIFF
--- a/mlforecast/core.py
+++ b/mlforecast/core.py
@@ -148,7 +148,13 @@ class TimeSeries:
             warnings.warn("Setting num_threads to 1.")
             num_threads = 1
         self.lags = [] if lags is None else list(lags)
+        for lag in self.lags:
+            if lag <= 0 or not isinstance(lag, int):
+                raise ValueError("lags must be positive integers.")
         self.lag_transforms = {} if lag_transforms is None else lag_transforms
+        for lag in self.lag_transforms.keys():
+            if lag <= 0 or not isinstance(lag, int):
+                raise ValueError("keys of lag_transforms must be positive integers.")
         self.date_features = [] if date_features is None else list(date_features)
         self.num_threads = num_threads
         self.target_transforms = target_transforms

--- a/nbs/core.ipynb
+++ b/nbs/core.ipynb
@@ -603,7 +603,13 @@
     "            warnings.warn('Setting num_threads to 1.')\n",
     "            num_threads = 1\n",
     "        self.lags = [] if lags is None else list(lags)\n",
+    "        for lag in self.lags:\n",
+    "            if lag <= 0 or not isinstance(lag, int):\n",
+    "                raise ValueError('lags must be positive integers.')\n",
     "        self.lag_transforms = {} if lag_transforms is None else lag_transforms\n",
+    "        for lag in self.lag_transforms.keys():\n",
+    "            if lag <= 0 or not isinstance(lag, int):\n",
+    "                raise ValueError('keys of lag_transforms must be positive integers.')\n",
     "        self.date_features = [] if date_features is None else list(date_features)\n",
     "        self.num_threads = num_threads\n",
     "        self.target_transforms = target_transforms\n",
@@ -1105,6 +1111,17 @@
     "            new_values=values,\n",
     "            new_groups=new_groups,\n",
     "        )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#| hide\n",
+    "test_fail(lambda: TimeSeries(freq='D', lags=list(range(2))), contains='lags must be positive integers')\n",
+    "test_fail(lambda: TimeSeries(freq='D', lag_transforms={0: 1}), contains='keys of lag_transforms must be positive integers')"
    ]
   },
   {


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please make sure to provide a meaningful description and let us know that you've completed all the requirements in the checklist by marking them with an x.
-->

## Description
<!-- What this PR does. If this work is related to a specific issue please reference it here. -->
The lags that are used in the `lags` and the keys of the `lag_transforms` arguments must be positive integers, this adds checks to enforce that and avoid unexpected behavior.

Checklist:
- [x] This PR has a meaningful title and a clear description.
- [x] The tests pass.
- [x] All linting tasks pass.
- [x] The notebooks are clean.