### PR TITLE
redirect from github pages to mintlify

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -14,9 +14,14 @@ jobs:
   build-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Clone repo
+        uses: actions/checkout@v3
+      - name: Clone docs repo
+        uses: actions/checkout@v3
         with:
-          submodules: 'recursive'
+          repository: Nixtla/docs
+          ref: scripts
+          path: docs-scripts
       - uses: actions/setup-python@v4
         with:
           cache: "pip"
@@ -35,6 +40,8 @@ jobs:
         run: |
           cp nbs/mint.json _docs/mint.json
           cp docs-scripts/imgs/* _docs/
+      - name: Configure redirects for gh-pages
+        run: python docs-scripts/configure-redirects.py mlforecast
       - name: Deploy to Mintlify Docs
         if: github.event_name == 'push'
         uses: peaceiris/actions-gh-pages@v3
@@ -42,7 +49,14 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: docs
           publish_dir: ./_docs
-          # The following lines assign commit authorship to the official GH-Actions bot for deploys to `docs` branch.
-          # You can swap them out with your own user credentials.
+          user_name: github-actions[bot]
+          user_email: 41898282+github-actions[bot]@users.noreply.github.com
+      - name: Deploy to Github Pages
+        if: github.event_name == 'push'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./gh-pages
           user_name: github-actions[bot]
           user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,9 +1,0 @@
-name: Deploy to GitHub Pages
-on:
-  push:
-    branches: ["main"]
-  workflow_dispatch:
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    steps: [uses: fastai/workflows/quarto-ghp@master]

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "docs-scripts"]
-	path = docs-scripts
-	url = https://github.com/Nixtla/docs.git
-	branch = scripts


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please make sure to provide a meaningful description and let us know that you've completed all the requirements in the checklist by marking them with an x.
-->

## Description
<!-- What this PR does. If this work is related to a specific issue please reference it here. -->
Sets the github pages to redirect to mintlify so that hyperlinks like https://nixtla.github.io/mlforecast/docs/getting-started/quick_start_local.html continue to work but redirect to the mintlify documentation instead.

Checklist:
- [x] This PR has a meaningful title and a clear description.
- [x] The tests pass.
- [x] All linting tasks pass.
- [x] The notebooks are clean.