### PR TITLE
use coreforecast lag_transforms in benchmarks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,7 +116,7 @@ jobs:
           cache: 'pip'
 
       - name: Install dependencies
-        run: pip install . pytest pytest-benchmark
+        run: pip install ".[lag_transforms]" pytest pytest-benchmark
 
       - name: Run performance tests
         run: pytest --benchmark-group-by=func --benchmark-sort=fullname

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,12 +1,11 @@
 import numpy as np
-import pandas as pd
 import pytest
 from sklearn.base import BaseEstimator
 from sklearn.linear_model import LinearRegression
 from utilsforecast.losses import smape
-from window_ops.rolling import rolling_mean, rolling_max, rolling_min
 
 from mlforecast import MLForecast
+from mlforecast.lag_transforms import RollingMean, RollingMax, RollingMin
 from mlforecast.target_transforms import Differences, LocalStandardScaler
 from mlforecast.utils import generate_daily_series
 
@@ -52,10 +51,10 @@ def fcst():
         freq="D",
         lags=[1, 7, 14, 28],
         lag_transforms={
-            1: [(rolling_mean, 7)],
-            7: [(rolling_mean, 7), (rolling_min, 7), (rolling_max, 7)],
-            14: [(rolling_mean, 7), (rolling_min, 7), (rolling_max, 7)],
-            28: [(rolling_mean, 7), (rolling_min, 7), (rolling_max, 7)],
+            1 : [RollingMean(7)],
+            7 : [RollingMean(7), RollingMin(7), RollingMax(7)],
+            14: [RollingMean(7), RollingMin(7), RollingMax(7)],
+            28: [RollingMean(7), RollingMin(7), RollingMax(7)],
         },
         date_features=["dayofweek", "month", "year", "day"],
         target_transforms=[Differences([1, 7]), LocalStandardScaler()],


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please make sure to provide a meaningful description and let us know that you've completed all the requirements in the checklist by marking them with an x.
-->

## Description
<!-- What this PR does. If this work is related to a specific issue please reference it here. -->
Updates the performance tests to use the built-in lag transformations.

Checklist:
- [x] This PR has a meaningful title and a clear description.
- [x] The tests pass.
- [x] All linting tasks pass.
- [x] The notebooks are clean.