### PR TITLE
fix RollingStd typo

### DIFF
--- a/mlforecast/lag_transforms.py
+++ b/mlforecast/lag_transforms.py
@@ -69,7 +69,7 @@ class RollingMean(RollingBase):
 
 
 class RollingStd(RollingBase):
-    tfm_name = "Rollingstd"
+    tfm_name = "RollingStd"
 
 
 class RollingMin(RollingBase):

--- a/nbs/lag_transforms.ipynb
+++ b/nbs/lag_transforms.ipynb
@@ -129,7 +129,7 @@
     "    tfm_name = 'RollingMean'\n",
     "\n",
     "class RollingStd(RollingBase):\n",
-    "    tfm_name = 'Rollingstd'\n",
+    "    tfm_name = 'RollingStd'\n",
     "\n",
     "\n",
     "class RollingMin(RollingBase):\n",
@@ -353,6 +353,36 @@
    "source": [
     "#| hide\n",
     "ExponentiallyWeightedMean(0.7)._set_core_tfm(4).transform(ga)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f07fae6-37c9-4996-ac48-f5ae6c232ef0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#| hide\n",
+    "# check all transforms can be used correctly\n",
+    "tfms = [\n",
+    "    ExpandingMax(),\n",
+    "    ExpandingMean(),\n",
+    "    ExpandingMin(),\n",
+    "    ExpandingStd(),\n",
+    "    ExponentiallyWeightedMean(0.1),\n",
+    "    RollingMax(7),\n",
+    "    RollingMean(7),\n",
+    "    RollingMin(7),\n",
+    "    RollingStd(7),\n",
+    "    SeasonalRollingMax(7, 2),\n",
+    "    SeasonalRollingMean(7, 2),\n",
+    "    SeasonalRollingMin(7, 2),\n",
+    "    SeasonalRollingStd(7, 2),\n",
+    "]\n",
+    "for tfm in tfms:\n",
+    "    tfm._set_core_tfm(1)\n",
+    "    tfm.transform(ga)\n",
+    "    tfm.update(ga)"
    ]
   }
  ],


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please make sure to provide a meaningful description and let us know that you've completed all the requirements in the checklist by marking them with an x.
-->

## Description
<!-- What this PR does. If this work is related to a specific issue please reference it here. -->
Fixes a typo that would cause the RollingStd lag_transform to fail.

Checklist:
- [x] This PR has a meaningful title and a clear description.
- [x] The tests pass.
- [x] All linting tasks pass.
- [x] The notebooks are clean.