### PR TITLE
add step to trigger mintlify workflow

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -51,6 +51,18 @@ jobs:
           publish_dir: ./_docs
           user_name: github-actions[bot]
           user_email: 41898282+github-actions[bot]@users.noreply.github.com
+      - name: Trigger mintlify workflow
+        if: github.event_name == 'push'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.DOCS_WORKFLOW_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'nixtla',
+              repo: 'docs',
+              workflow_id: 'mintlify-action.yml',
+              ref: 'main',
+            });
       - name: Deploy to Github Pages
         if: github.event_name == 'push'
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please make sure to provide a meaningful description and let us know that you've completed all the requirements in the checklist by marking them with an x.
-->

## Description
<!-- What this PR does. If this work is related to a specific issue please reference it here. -->

This adds a step to the `build-docs` workflow to trigger a workflow run in `nixtla/docs`

Checklist:
- [x] This PR has a meaningful title and a clear description.
- [ ] The tests pass.
- [ ] All linting tasks pass.
- [ ] The notebooks are clean.