### PR TITLE
run codspeed benchmarks in parallel

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,16 +88,16 @@ jobs:
 
       - uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # 5.1.1
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Install dependencies
-        run: pip install uv && uv pip install --system . pytest pytest-codspeed
+        run: pip install uv && uv pip install --system . pytest-codspeed pytest-xdist
 
       - name: Run benchmarks
         uses: CodSpeedHQ/action@a58b84c0b61569a9cbb7cfb378cc849d65cf1ce5 # 2.4.3
         with:
           token: ${{ secrets.CODESPEED_TOKEN }}
-          run: pytest tests/test_pipeline.py --codspeed
+          run: pytest tests/test_pipeline.py --codspeed -n 2
 
   performance-tests:
     runs-on: ubuntu-latest

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -20,7 +20,7 @@ class SeasonalNaive(BaseEstimator):
 
 @pytest.fixture(scope="module")
 def series():
-    n_series = 2_000
+    n_series = 1_000
     n_static = 10
     return generate_daily_series(
         n_series=n_series,


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please make sure to provide a meaningful description and let us know that you've completed all the requirements in the checklist by marking them with an x.
-->

## Description
<!-- What this PR does. If this work is related to a specific issue please reference it here. -->
Reduces the time to run the benchmarks by using two processes to run the tests and reducing the size of the series used.

Checklist:
- [ ] This PR has a meaningful title and a clear description.
- [ ] The tests pass.
- [ ] All linting tasks pass.
- [ ] The notebooks are clean.