### PR TITLE
[FIX] Use sample weights in cross validation

### DIFF
--- a/mlforecast/forecast.py
+++ b/mlforecast/forecast.py
@@ -856,6 +856,7 @@ class MLForecast:
                 target_col=self.ts.target_col,
                 static_features=self.ts.static_features,
                 keep_last_n=self.ts.keep_last_n,
+                weight_col=self.ts.weight_col,
             )
             core_tfms = new_ts._get_core_lag_tfms()
             if core_tfms:


### PR DESCRIPTION
When cross_validation is called with `weight_col` and `refit=False`, the predict method creates a new TimeSeries object to process data for non-refit windows. This new TimeSeries was not being initialized with the weight_col parameter, causing it to treat the weight column as a feature rather than excluding it.

The fix passes `weight_col=self.ts.weight_col` to` new_ts._fit()` in the predict method, ensuring the temporary TimeSeries is configured consistently with the original.

Fixes #497