### PR TITLE
[FEAT] Implements sample_weight usage in distributed learning API

### DIFF
--- a/mlforecast/core.py
+++ b/mlforecast/core.py
@@ -142,6 +142,37 @@ TargetTransform = Union[BaseTargetTransform, _BaseGroupedArrayTargetTransform]
 Transforms = Dict[str, Union[Tuple[Any, ...], _BaseLagTransform]]
 
 
+def _validate_horizon_params(
+    max_horizon: Optional[int], horizons: Optional[List[int]]
+) -> Tuple[Optional[List[int]], Optional[int]]:
+    """Validate and normalize horizon parameters.
+
+    Args:
+        max_horizon: Train models for all horizons 1 to max_horizon.
+        horizons: Train models only for specific horizons (1-indexed).
+
+    Returns:
+        Tuple of (internal_horizons, effective_max_horizon):
+        - internal_horizons: 0-indexed list of horizons, or None for recursive mode
+        - effective_max_horizon: Maximum horizon value (for target expansion)
+    """
+    if max_horizon is not None and horizons is not None:
+        raise ValueError("Cannot specify both 'max_horizon' and 'horizons'")
+
+    if horizons is not None:
+        if not horizons:
+            raise ValueError("'horizons' cannot be empty")
+        if not all(isinstance(h, int) and h > 0 for h in horizons):
+            raise ValueError("All horizons must be positive integers")
+        horizons = sorted(set(horizons))  # dedupe and sort
+        return [h - 1 for h in horizons], max(horizons)  # 0-indexed, max
+
+    if max_horizon is not None:
+        return list(range(max_horizon)), max_horizon
+
+    return None, None
+
+
 def _parse_transforms(
     lags: Lags,
     lag_transforms: LagTransforms,
@@ -529,12 +560,27 @@ class TimeSeries:
         df: DFType,
         dropna: bool = True,
         max_horizon: Optional[int] = None,
+        horizons: Optional[List[int]] = None,
         return_X_y: bool = False,
         as_numpy: bool = False,
     ) -> DFType:
         """Add the features to `df`.
 
-        if `dropna=True` then all the null rows are dropped."""
+        if `dropna=True` then all the null rows are dropped.
+
+        Args:
+            df: Input dataframe
+            dropna: Drop rows with missing values
+            max_horizon: Train models for all horizons 1 to max_horizon
+            horizons: Train models only for specific horizons (1-indexed)
+            return_X_y: Return tuple of (X, y) instead of dataframe
+            as_numpy: Convert X to numpy array
+        """
+        # Validate and normalize horizon parameters
+        self._horizons, effective_max_horizon = _validate_horizon_params(
+            max_horizon, horizons
+        )
+
         # we need to compute all transformations in case they save state
         features = self._compute_transforms(
             transforms=self.transforms, updates_only=False
@@ -595,11 +641,11 @@ class TimeSeries:
                 features[k] = v[self._restore_idxs]
 
         # target
-        self.max_horizon = max_horizon
-        if max_horizon is None:
+        self.max_horizon = effective_max_horizon
+        if effective_max_horizon is None:
             target = self.ga.data
         else:
-            target = self.ga.expand_target(max_horizon)
+            target = self.ga.expand_target(effective_max_horizon)
         if self._restore_idxs is not None:
             target = target[self._restore_idxs]
 
@@ -698,11 +744,11 @@ class TimeSeries:
             if as_numpy:
                 X = ufp.to_numpy(X)
             return X, target
-        if max_horizon is not None:
+        if effective_max_horizon is not None:
             # remove original target
             out_cols = [c for c in df.columns if c != self.target_col]
             df = df[out_cols]
-            target_names = [f"{self.target_col}{i}" for i in range(max_horizon)]
+            target_names = [f"{self.target_col}{i}" for i in range(effective_max_horizon)]
             df = ufp.assign_columns(df, target_names, target)
         else:
             df = ufp.copy_if_pandas(df, deep=False)
@@ -713,11 +759,11 @@ class TimeSeries:
         self,
         prep: DFType,
         original_df: DFType,
-        max_horizon: int,
+        horizons: List[int],
         target_col: str,
         as_numpy: bool = False,
-    ) -> Iterator[Tuple[Union[DFType, np.ndarray], np.ndarray]]:
-        """Generator that yields (X, y) tuples for each horizon.
+    ) -> Iterator[Tuple[int, Union[DFType, np.ndarray], np.ndarray]]:
+        """Generator that yields (h, X, y) tuples for each horizon.
 
         For horizon h:
         - Dynamic exogenous features are aligned to predict h steps ahead
@@ -727,9 +773,12 @@ class TimeSeries:
         Args:
             prep: Preprocessed dataframe with expanded targets (y0, y1, ..., y{max_horizon-1})
             original_df: Original input dataframe for exog feature lookup
-            max_horizon: Number of horizons
+            horizons: List of horizons to process (0-indexed)
             target_col: Name of target column
             as_numpy: Whether to convert X to numpy array
+
+        Yields:
+            Tuple of (horizon_index, X, y) where horizon_index is 0-indexed
         """
         exog_cols = self._get_dynamic_exog_cols(list(original_df.columns))
 
@@ -742,18 +791,18 @@ class TimeSeries:
         # Non-exog feature columns (lags, date features, static)
         non_exog_cols = [c for c in x_cols if c not in exog_cols]
 
-        # Target column names (y0, y1, ..., y{max_horizon-1})
-        target_cols = [f"{target_col}{i}" for i in range(max_horizon)]
-
         # Build exog lookup dictionary from original_df for efficient lookups
         # Key: (id, time) -> exog values
         if exog_cols:
             # Create a lookup dataframe indexed by (id, time)
             exog_lookup = original_df[[self.id_col, self.time_col] + exog_cols]
 
-        for h in range(max_horizon):
+        for h in horizons:
+            # Target column name for this horizon
+            target_col_h = f"{target_col}{h}"
+
             # Get target for this horizon
-            y_h = prep[target_cols[h]].to_numpy()
+            y_h = prep[target_col_h].to_numpy()
 
             if h == 0 or not exog_cols:
                 # No offset needed for horizon 0 or if no exog cols
@@ -809,7 +858,7 @@ class TimeSeries:
             if as_numpy:
                 X_h = ufp.to_numpy(X_h)
 
-            yield X_h, y_h
+            yield h, X_h, y_h
 
     def fit_transform(
         self,
@@ -821,6 +870,7 @@ class TimeSeries:
         dropna: bool = True,
         keep_last_n: Optional[int] = None,
         max_horizon: Optional[int] = None,
+        horizons: Optional[List[int]] = None,
         return_X_y: bool = False,
         as_numpy: bool = False,
         weight_col: Optional[str] = None,
@@ -830,6 +880,11 @@ class TimeSeries:
         If not all features are static, specify which ones are in `static_features`.
         If you don't want to drop rows with null values after the transformations set `dropna=False`
         If `keep_last_n` is not None then that number of observations is kept across all series for updates.
+
+        Args:
+            max_horizon: Train models for all horizons 1 to max_horizon.
+            horizons: Train models only for specific horizons (1-indexed).
+                      Mutually exclusive with max_horizon.
         """
         self.dropna = dropna
         self.as_numpy = as_numpy
@@ -846,6 +901,7 @@ class TimeSeries:
             df=data,
             dropna=dropna,
             max_horizon=max_horizon,
+            horizons=horizons,
             return_X_y=return_X_y,
             as_numpy=as_numpy,
         )
@@ -1038,7 +1094,7 @@ class TimeSeries:
 
     def _predict_multi(
         self,
-        models: Dict[str, BaseEstimator],
+        models: Dict[str, Dict[int, BaseEstimator]],
         horizon: int,
         before_predict_callback: Optional[Callable] = None,
         X_df: Optional[DFType] = None,
@@ -1048,27 +1104,84 @@ class TimeSeries:
             raise ValueError(
                 f"horizon must be at most max_horizon ({self.max_horizon})"
             )
-        self._predict_setup()
-        uids = self._get_future_ids(horizon)
-        starts = ufp.offset_times(self.curr_dates, self.freq, 1)
-        dates = ufp.time_ranges(starts, self.freq, periods=horizon)
-        if isinstance(self.curr_dates, pl_Series):
-            df_constructor = pl_DataFrame
+
+        # Determine horizons to predict based on _horizons (sparse) or all up to horizon
+        internal_horizons = getattr(self, "_horizons", None)
+
+        # Check if horizons are sparse (not a contiguous range from 0)
+        full_range = list(range(self.max_horizon))
+        is_sparse = internal_horizons is not None and internal_horizons != full_range
+
+        if is_sparse:
+            # Sparse horizons: filter to those <= requested horizon (0-indexed)
+            assert internal_horizons is not None  # mypy: guaranteed by is_sparse check
+            horizons_to_predict = [h for h in internal_horizons if h < horizon]
+            if not horizons_to_predict:
+                raise ValueError(
+                    f"No trained horizons available for prediction up to h={horizon}. "
+                    f"Trained horizons (1-indexed): {[h + 1 for h in internal_horizons]}"
+                )
+            output_horizon = len(horizons_to_predict)
         else:
-            df_constructor = pd.DataFrame
+            # Full horizons: predict all from 0 to horizon-1
+            horizons_to_predict = list(range(horizon))
+            output_horizon = horizon
+
+        self._predict_setup()
+        uids = self._get_future_ids(output_horizon)
+
+        if is_sparse:
+            # Generate dates only for the specific horizons we're predicting
+            # uids structure is [s0, s0, ..., s0 (output_horizon times), s1, s1, ..., s1, ...]
+            # So dates need to be [s0_h0, s0_h1, ..., s1_h0, s1_h1, ...]
+            if isinstance(self.curr_dates, pl_Series):
+                df_constructor = pl_DataFrame
+                # Compute dates for all horizons, then stack and flatten
+                dates_per_horizon = [ufp.offset_times(self.curr_dates, self.freq, h + 1) for h in horizons_to_predict]
+                # Stack: each row is a series, each col is a horizon
+                dates_matrix = pl.DataFrame(dates_per_horizon).transpose()
+                # Flatten row by row: [s0_h0, s0_h1, ..., s1_h0, s1_h1, ...]
+                dates = dates_matrix.to_numpy().ravel()
+                dates = pl.Series(dates)
+            else:
+                df_constructor = pd.DataFrame
+                # Compute dates for all horizons, then stack and flatten
+                dates_per_horizon = [ufp.offset_times(self.curr_dates, self.freq, h + 1) for h in horizons_to_predict]
+                # Stack: each row is a series, each col is a horizon
+                dates_matrix = np.column_stack(dates_per_horizon)
+                # Flatten row by row: [s0_h0, s0_h1, ..., s1_h0, s1_h1, ...]
+                dates = dates_matrix.ravel()
+        else:
+            # Original behavior: generate contiguous date range
+            starts = ufp.offset_times(self.curr_dates, self.freq, 1)
+            dates = ufp.time_ranges(starts, self.freq, periods=horizon)
+            if isinstance(self.curr_dates, pl_Series):
+                df_constructor = pl_DataFrame
+            else:
+                df_constructor = pd.DataFrame
+
         result = df_constructor({self.id_col: uids, self.time_col: dates})
+
         for name, model in models.items():
             with self._backup():
                 self._predict_setup()
-                predictions = np.empty((len(self.uids), horizon))
-                for i in range(horizon):
-                    new_x = self._get_features_for_next_step(X_df)
+                predictions = np.empty((len(self.uids), output_horizon))
+
+                for out_idx, h in enumerate(horizons_to_predict):
+                    # Advance features to the correct horizon step
+                    # We need to step through all horizons up to h to maintain state
+                    while self._h <= h:
+                        new_x = self._get_features_for_next_step(X_df)
+
                     if before_predict_callback is not None:
                         new_x = before_predict_callback(new_x)
-                    preds = model[i].predict(new_x)
+
+                    horizon_model = model[h]
+                    preds = horizon_model.predict(new_x)
                     if len(preds) != len(self.uids):
                         raise ValueError(f"Model returned {len(preds)} predictions but expected {len(self.uids)}")
-                    predictions[:, i] = preds
+                    predictions[:, out_idx] = preds
+
                 raw_preds = predictions.ravel()
                 result = ufp.assign_columns(result, name, raw_preds)
         return result
@@ -1116,7 +1229,7 @@ class TimeSeries:
 
     def predict(
         self,
-        models: Dict[str, Union[BaseEstimator, List[BaseEstimator]]],
+        models: Dict[str, Union[BaseEstimator, Dict[int, BaseEstimator]]],
         horizon: int,
         before_predict_callback: Optional[Callable] = None,
         after_predict_callback: Optional[Callable] = None,
@@ -1210,7 +1323,9 @@ class TimeSeries:
                         for c in preds.columns
                         if c not in (self.id_col, self.time_col)
                     ]
-                    indptr = np.arange(0, horizon * (len(self.uids) + 1), horizon)
+                    # Calculate actual predictions per series (handles sparse horizons)
+                    preds_per_series = len(preds) // len(self.uids)
+                    indptr = np.arange(0, preds_per_series * (len(self.uids) + 1), preds_per_series)
                 for tfm in self.target_transforms[::-1]:
                     if isinstance(tfm, _BaseGroupedArrayTargetTransform):
                         for col in model_cols:

--- a/mlforecast/distributed/models/spark/lgb.py
+++ b/mlforecast/distributed/models/spark/lgb.py
@@ -23,7 +23,9 @@ except ModuleNotFoundError:
 
 
 class SparkLGBMForecast(LightGBMRegressor):
-    def _pre_fit(self, target_col):
+    def _pre_fit(self, target_col, weight_col=None):
+        if weight_col is not None and hasattr(self, "setWeightCol"):
+            return self.setLabelCol(target_col).setWeightCol(weight_col)
         return self.setLabelCol(target_col)
 
     def extract_local_model(self, trained_model):

--- a/mlforecast/distributed/models/spark/xgb.py
+++ b/mlforecast/distributed/models/spark/xgb.py
@@ -15,8 +15,10 @@ except ModuleNotFoundError:
 
 
 class SparkXGBForecast(SparkXGBRegressor):
-    def _pre_fit(self, target_col):
+    def _pre_fit(self, target_col, weight_col=None):
         self.setParams(label_col=target_col)
+        if weight_col is not None:
+            self.setParams(weight_col=weight_col)
         return self
 
     def extract_local_model(self, trained_model):

--- a/mlforecast/forecast.py
+++ b/mlforecast/forecast.py
@@ -212,6 +212,7 @@ class MLForecast:
         dropna: bool = True,
         keep_last_n: Optional[int] = None,
         max_horizon: Optional[int] = None,
+        horizons: Optional[List[int]] = None,
         return_X_y: bool = False,
         as_numpy: bool = False,
         weight_col: Optional[str] = None,
@@ -227,6 +228,7 @@ class MLForecast:
             dropna (bool): Drop rows with missing values produced by the transformations. Defaults to True.
             keep_last_n (int, optional): Keep only these many records from each serie for the forecasting step. Can save time and memory if your features allow it. Defaults to None.
             max_horizon (int, optional): Train this many models, where each model will predict a specific horizon. Defaults to None.
+            horizons (list of int, optional): Train models only for specific horizons (1-indexed). Mutually exclusive with max_horizon. Defaults to None.
             return_X_y (bool): Return a tuple with the features and the target. If False will return a single dataframe. Defaults to False.
             as_numpy (bool): Cast features to numpy array. Only works for `return_X_y=True`. Defaults to False.
             weight_col (str, optional): Column that contains the sample weights. Defaults to None.
@@ -243,6 +245,7 @@ class MLForecast:
             dropna=dropna,
             keep_last_n=keep_last_n,
             max_horizon=max_horizon,
+            horizons=horizons,
             return_X_y=return_X_y,
             as_numpy=as_numpy,
             weight_col=weight_col,
@@ -258,10 +261,10 @@ class MLForecast:
         """Manually train models. Use this if you called `MLForecast.preprocess` beforehand.
 
         Args:
-            X (pandas or polars DataFrame or numpy array, optional): Features (for recursive or legacy direct forecasting).
-            y (numpy array, optional): Target (for recursive or legacy direct forecasting).
+            X (pandas or polars DataFrame or numpy array, optional): Features (for recursive forecasting).
+            y (numpy array, optional): Target (for recursive forecasting).
             models_fit_kwargs (dict, optional): Keyword arguments for each model's fit method.
-            generator_factory (callable, optional): Factory function that returns an iterator yielding (X_h, y_h) tuples per horizon.
+            generator_factory (callable, optional): Factory function that returns an iterator yielding (h, X_h, y_h) tuples per horizon.
 
         Returns:
             MLForecast: Forecast object with trained models.
@@ -288,43 +291,27 @@ class MLForecast:
                     X = ufp.drop_columns(X, weight_col)
             return clone(model).fit(X, y, **fit_kwargs)
 
-        self.models_: Dict[str, Union[BaseEstimator, List[BaseEstimator]]] = {}
+        self.models_: Dict[str, Union[BaseEstimator, Dict[int, BaseEstimator]]] = {}
 
         if generator_factory is not None:
             # Direct forecasting with generator factory
+            # Models are stored as dict keyed by horizon index (0-indexed)
             for name, model in self.models.items():
                 model_fit_kwargs = models_fit_kwargs.get(name, None)
-                self.models_[name] = []
+                self.models_[name] = {}
                 # Create fresh generator for each model (generators are single-use)
                 horizon_gen = generator_factory()
-                for h, (X_h, y_h) in enumerate(horizon_gen):
+                for h, X_h, y_h in horizon_gen:
                     fitted = fit_model(model, X_h, y_h, self.ts.weight_col, model_fit_kwargs)
-                    self.models_[name].append(fitted)
+                    self.models_[name][h] = fitted
         else:
             # Recursive forecasting (unchanged)
             assert X is not None and y is not None, "X and y are required when generator_factory is not provided"
             for name, model in self.models.items():
                 model_fit_kwargs = models_fit_kwargs.get(name, None)
-                if y.ndim == 2 and y.shape[1] > 1:
-                    # Legacy direct forecasting (without generator)
-                    self.models_[name] = []
-                    for horizon in range(y.shape[1]):
-                        keep = ~np.isnan(y[:, horizon])
-                        Xh = ufp.filter_with_mask(X, keep)
-                        yh = y[keep, horizon]
-                        self.models_[name].append(
-                            fit_model(
-                                model,
-                                Xh,
-                                yh,
-                                self.ts.weight_col,
-                                model_fit_kwargs,
-                            )
-                        )
-                else:
-                    self.models_[name] = fit_model(
-                        model, X, y, self.ts.weight_col, model_fit_kwargs
-                    )
+                self.models_[name] = fit_model(
+                    model, X, y, self.ts.weight_col, model_fit_kwargs
+                )
         return self
 
     def _conformity_scores(
@@ -337,6 +324,7 @@ class MLForecast:
         dropna: bool = True,
         keep_last_n: Optional[int] = None,
         max_horizon: Optional[int] = None,
+        horizons: Optional[List[int]] = None,
         n_windows: int = 2,
         h: int = 1,
         as_numpy: bool = False,
@@ -371,6 +359,7 @@ class MLForecast:
             dropna=dropna,
             keep_last_n=keep_last_n,
             max_horizon=max_horizon,
+            horizons=horizons,
             prediction_intervals=None,
             as_numpy=as_numpy,
         )
@@ -451,7 +440,7 @@ class MLForecast:
         if max_horizon is None:
             fitted_values = ufp.assign_columns(base, target_col, y)
             for name, model in self.models_.items():
-                assert not isinstance(model, list)  # mypy
+                assert not isinstance(model, dict)  # mypy
                 preds = model.predict(X)
                 fitted_values = ufp.assign_columns(fitted_values, name, preds)
             fitted_values = self._invert_transforms_fitted(fitted_values)
@@ -473,7 +462,9 @@ class MLForecast:
             models_trained_with_numpy = self.ts.as_numpy
 
             for name, horizon_models in self.models_.items():
-                for h, model in enumerate(horizon_models):
+                model_items = horizon_models.items()
+
+                for h, model in model_items:
                     # Get valid mask for this horizon (target not NaN)
                     y_h = y[:, h] if y.ndim == 2 else y
                     valid_target = ~np.isnan(y_h)
@@ -601,6 +592,7 @@ class MLForecast:
         dropna: bool = True,
         keep_last_n: Optional[int] = None,
         max_horizon: Optional[int] = None,
+        horizons: Optional[List[int]] = None,
         prediction_intervals: Optional[PredictionIntervals] = None,
         fitted: bool = False,
         as_numpy: bool = False,
@@ -618,6 +610,7 @@ class MLForecast:
             dropna (bool): Drop rows with missing values produced by the transformations. Defaults to True.
             keep_last_n (int, optional): Keep only these many records from each serie for the forecasting step. Can save time and memory if your features allow it. Defaults to None.
             max_horizon (int, optional): Train this many models, where each model will predict a specific horizon. Defaults to None.
+            horizons (list of int, optional): Train models only for specific horizons (1-indexed). For example, `horizons=[7, 14]` trains models only for steps 7 and 14. Mutually exclusive with max_horizon. Defaults to None.
             prediction_intervals (PredictionIntervals, optional): Configuration to calibrate prediction intervals (Conformal Prediction). Defaults to None.
             fitted (bool): Save in-sample predictions. Defaults to False.
             as_numpy (bool): Cast features to numpy array. Defaults to False.
@@ -641,12 +634,14 @@ class MLForecast:
                 static_features=static_features,
                 dropna=dropna,
                 keep_last_n=keep_last_n,
+                max_horizon=max_horizon,
+                horizons=horizons,
                 n_windows=prediction_intervals.n_windows,
                 h=prediction_intervals.h,
                 as_numpy=as_numpy,
             )
-        # When max_horizon is set, use generator factory approach
-        if max_horizon is not None:
+        # When max_horizon or horizons is set, use generator factory approach
+        if max_horizon is not None or horizons is not None:
             # Preprocess to get DataFrame with expanded targets
             prep = self.preprocess(
                 df=df,
@@ -656,7 +651,8 @@ class MLForecast:
                 static_features=static_features,
                 dropna=dropna,
                 keep_last_n=keep_last_n,
-                max_horizon=max_horizon,  # Expand targets
+                max_horizon=max_horizon,
+                horizons=horizons,
                 return_X_y=False,
                 as_numpy=False,
                 weight_col=weight_col,
@@ -664,13 +660,17 @@ class MLForecast:
             # Restore the as_numpy setting for prediction
             self.ts.as_numpy = as_numpy
 
+            # Get the effective max horizon and internal horizons from preprocessing
+            effective_max_horizon = self.ts.max_horizon
+            internal_horizons = self.ts._horizons
+
             # Store original df for exog lookup in generator
             original_df = df
 
             # Factory function - creates fresh generator for each model
             def generator_factory():
                 return self.ts._transform_per_horizon(
-                    prep, original_df, max_horizon, target_col, as_numpy
+                    prep, original_df, internal_horizons, target_col, as_numpy
                 )
 
             # Train models using generator factory
@@ -689,7 +689,7 @@ class MLForecast:
                     id_col=id_col,
                     time_col=time_col,
                     target_col=target_col,
-                    max_horizon=max_horizon,
+                    max_horizon=effective_max_horizon,
                     weight_col=self.ts.weight_col,
                     original_df=original_df,
                 )
@@ -821,14 +821,16 @@ class MLForecast:
                 "No fitted models found. You have to call fit or preprocess + fit_models. "
                 "If you used cross_validation before please fit again."
             )
-        first_model_is_list = isinstance(next(iter(self.models_.values())), list)
+        first_model = next(iter(self.models_.values()))
+        # Models are stored as dict for direct forecasting
+        first_model_is_multi = isinstance(first_model, dict)
         max_horizon = self.ts.max_horizon
-        if first_model_is_list and max_horizon is None:
+        if first_model_is_multi and max_horizon is None:
             raise ValueError(
                 "Found one model per horizon but `max_horizon` is None. "
                 "If you ran preprocess after fit please run fit again."
             )
-        elif not first_model_is_list and max_horizon is not None:
+        elif not first_model_is_multi and max_horizon is not None:
             raise ValueError(
                 "Found a single model for all horizons "
                 f"but `max_horizon` is {max_horizon}. "
@@ -938,6 +940,7 @@ class MLForecast:
         keep_last_n: Optional[int] = None,
         refit: Union[bool, int] = True,
         max_horizon: Optional[int] = None,
+        horizons: Optional[List[int]] = None,
         before_predict_callback: Optional[Callable] = None,
         after_predict_callback: Optional[Callable] = None,
         prediction_intervals: Optional[PredictionIntervals] = None,
@@ -963,6 +966,7 @@ class MLForecast:
             dropna (bool): Drop rows with missing values produced by the transformations. Defaults to True.
             keep_last_n (int, optional): Keep only these many records from each serie for the forecasting step. Can save time and memory if your features allow it. Defaults to None.
             max_horizon (int, optional): Train this many models, where each model will predict a specific horizon. Defaults to None.
+            horizons (list of int, optional): Train models only for specific horizons (1-indexed). Mutually exclusive with max_horizon. Defaults to None.
             refit (bool or int): Retrain model for each cross validation window. If False, the models are trained at the beginning and then used to predict each window. If positive int, the models are retrained every `refit` windows. Defaults to True.
             before_predict_callback (callable, optional): Function to call on the features before computing the predictions. This function will take the input dataframe that will be passed to the model for predicting and should return a dataframe with the same structure. The series identifier is on the index. Defaults to None.
             after_predict_callback (callable, optional): Function to call on the predictions before updating the targets. This function will take a pandas Series with the predictions and should return another one with the same structure. The series identifier is on the index. Defaults to None.
@@ -1001,6 +1005,7 @@ class MLForecast:
                     dropna=dropna,
                     keep_last_n=keep_last_n,
                     max_horizon=max_horizon,
+                    horizons=horizons,
                     prediction_intervals=prediction_intervals,
                     fitted=fitted,
                     as_numpy=as_numpy,
@@ -1024,11 +1029,13 @@ class MLForecast:
                     static_features=static_features,
                     dropna=dropna,
                     keep_last_n=keep_last_n,
-                    max_horizon=max_horizon,  # Expand targets if max_horizon is set
+                    max_horizon=max_horizon,
+                    horizons=horizons,
                     return_X_y=False,
                     weight_col=weight_col,
                 )
                 assert not isinstance(prep, tuple)
+                effective_max_horizon = self.ts.max_horizon
                 base = prep[[id_col, time_col]]
                 train_X, train_y = self._extract_X_y(prep, target_col, weight_col)
                 if as_numpy:
@@ -1041,9 +1048,9 @@ class MLForecast:
                     id_col=id_col,
                     time_col=time_col,
                     target_col=target_col,
-                    max_horizon=max_horizon,
+                    max_horizon=effective_max_horizon,
                     weight_col=weight_col,
-                    original_df=train if max_horizon is not None else None,
+                    original_df=train if effective_max_horizon is not None else None,
                 )
                 fitted_values = ufp.assign_columns(fitted_values, "fold", i_window)
                 cv_fitted_values.append(fitted_values)
@@ -1076,7 +1083,19 @@ class MLForecast:
             sort_idxs = ufp.maybe_compute_sort_indices(result, id_col, time_col)
             if sort_idxs is not None:
                 result = ufp.take_rows(result, sort_idxs)
-            if result.shape[0] < valid.shape[0]:
+            # Calculate expected rows accounting for sparse horizons
+            internal_horizons = getattr(self.ts, "_horizons", None)
+            full_range = list(range(self.ts.max_horizon)) if self.ts.max_horizon else None
+            is_sparse = internal_horizons is not None and internal_horizons != full_range
+            if is_sparse:
+                # Sparse horizons: expect only predictions for trained horizons <= h
+                assert internal_horizons is not None
+                n_trained_horizons = sum(th < h for th in internal_horizons)
+                n_series = valid[id_col].nunique()
+                expected_rows = n_trained_horizons * n_series
+            else:
+                expected_rows = valid.shape[0]
+            if result.shape[0] < expected_rows:
                 raise ValueError(
                     "Cross validation result produced less results than expected. "
                     "Please verify that the frequency set on the MLForecast constructor matches your series' "

--- a/nbs/docs/how-to-guides/one_model_per_horizon.ipynb
+++ b/nbs/docs/how-to-guides/one_model_per_horizon.ipynb
@@ -28,7 +28,15 @@
    "source": [
     "By default mlforecast uses the recursive strategy, i.e. a model is trained to predict the next value and if we're predicting several values we do it one at a time and then use the model's predictions as the new target, recompute the features and predict the next step.\n",
     "\n",
-    "There's another approach where if we want to predict 10 steps ahead we train 10 different models, where each model is trained to predict the value at each specific step, i.e. one model predicts the next value, another one predicts the value two steps ahead and so on. This can be very time consuming but can also provide better results. If you want to use this approach you can specify `max_horizon` in `MLForecast.fit`, which will train that many models and each model will predict its corresponding horizon when you call `MLForecast.predict`."
+    "There's another approach called **direct forecasting** where if we want to predict 10 steps ahead we train 10 different models, where each model is trained to predict the value at each specific step, i.e. one model predicts the next value, another one predicts the value two steps ahead and so on. This can be very time consuming but can also provide better results.\n",
+    "\n",
+    "mlforecast provides two ways to use direct forecasting:\n",
+    "\n",
+    "1. **`max_horizon`**: Train models for all horizons from 1 to `max_horizon`. For example, `max_horizon=10` trains 10 models (for steps 1, 2, 3, ..., 10).\n",
+    "\n",
+    "2. **`horizons`**: Train models only for specific horizons. For example, `horizons=[7, 14]` trains only 2 models (for steps 7 and 14), which reduces computational cost when you only need predictions at certain steps.\n",
+    "\n",
+    "Both parameters are mutually exclusive - you can use one or the other, but not both."
    ]
   },
   {
@@ -41,7 +49,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "5d48bcd4-6fdc-41b3-adc9-3d5f83197028",
    "metadata": {},
    "outputs": [],
@@ -76,7 +84,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "90fc0561-04fc-4bfe-b823-1fe5d09bd90a",
    "metadata": {},
    "outputs": [],
@@ -97,7 +105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "ad1761c0-60af-4e13-97fc-e991b5361c5e",
    "metadata": {},
    "outputs": [],
@@ -118,12 +126,12 @@
    "id": "ed8bd708-d042-485b-8a00-d699680cf2db",
    "metadata": {},
    "source": [
-    "## Model"
+    "## Using `max_horizon` (all horizons)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "bf2837f5-e579-4f02-88b5-e3866e9c049d",
    "metadata": {},
    "outputs": [],
@@ -144,7 +152,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "6ec0b126-1367-49a8-a3f4-235fee969908",
    "metadata": {},
    "outputs": [
@@ -153,6 +161,14 @@
      "output_type": "stream",
      "text": [
       "Average SMAPE per method and series\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/cc/cylsfhls0hb_9wg0wh8tvpyh0000gn/T/ipykernel_4013/3601618158.py:15: FutureWarning: DataFrame.applymap has been deprecated. Use DataFrame.map instead.\n",
+      "  avg_smape_individual.to_frame().join(avg_smape_recursive).applymap('{:.1%}'.format)\n"
      ]
     },
     {
@@ -176,7 +192,7 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>individual</th>\n",
+       "      <th>direct</th>\n",
        "      <th>recursive</th>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -198,7 +214,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>H381</th>\n",
-       "      <td>20.9%</td>\n",
+       "      <td>19.5%</td>\n",
        "      <td>9.5%</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -211,55 +227,454 @@
        "</div>"
       ],
       "text/plain": [
-       "          individual recursive\n",
-       "unique_id                     \n",
-       "H196            0.3%      0.3%\n",
-       "H256            0.4%      0.3%\n",
-       "H381           20.9%      9.5%\n",
-       "H413           11.9%     13.6%"
+       "          direct recursive\n",
+       "unique_id                 \n",
+       "H196        0.3%      0.3%\n",
+       "H256        0.4%      0.3%\n",
+       "H381       19.5%      9.5%\n",
+       "H413       11.9%     13.6%"
       ]
      },
-     "execution_count": null,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "horizon = 24\n",
-    "# the following will train 24 models, one for each horizon\n",
+    "\n",
+    "# Train 24 models using max_horizon (one for each step from 1 to 24)\n",
     "individual_fcst = fcst.fit(train, max_horizon=horizon)\n",
     "individual_preds = individual_fcst.predict(horizon)\n",
-    "avg_smape_individual = avg_smape(individual_preds).rename('individual')\n",
-    "# the following will train a single model and use the recursive strategy\n",
+    "avg_smape_individual = avg_smape(individual_preds).rename('direct')\n",
+    "\n",
+    "# Train a single model using the recursive strategy\n",
     "recursive_fcst = fcst.fit(train)\n",
     "recursive_preds = recursive_fcst.predict(horizon)\n",
     "avg_smape_recursive = avg_smape(recursive_preds).rename('recursive')\n",
-    "# results\n",
+    "\n",
+    "# Compare results\n",
     "print('Average SMAPE per method and series')\n",
     "avg_smape_individual.to_frame().join(avg_smape_recursive).applymap('{:.1%}'.format)"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "430eff81-dd27-42bf-b852-093ded7fc2e2",
+   "cell_type": "markdown",
+   "id": "qqno86kz29b",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "#| echo: false\n",
-    "# we get the same prediction for the first timestep\n",
-    "pd.testing.assert_frame_equal(\n",
-    "    individual_preds.groupby('unique_id').head(1).astype({'ds': 'int64'}),\n",
-    "    recursive_preds.groupby('unique_id').head(1).astype({'ds': 'int64'}),    \n",
-    ")"
+    "## Using `horizons` (specific horizons only)\n",
+    "\n",
+    "When you only need predictions at specific time steps (e.g., weekly and bi-weekly forecasts), you can use the `horizons` parameter to train models only for those steps. This significantly reduces computational cost.\n",
+    "\n",
+    "For example, if you have hourly data and only need 12-hour and 24-hour ahead predictions:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "4y9aav9sc4b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of predictions per series: 2\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>unique_id</th>\n",
+       "      <th>ds</th>\n",
+       "      <th>LGBMRegressor</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>H196</td>\n",
+       "      <td>972</td>\n",
+       "      <td>16.095804</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>H196</td>\n",
+       "      <td>984</td>\n",
+       "      <td>15.696618</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>H256</td>\n",
+       "      <td>972</td>\n",
+       "      <td>13.295804</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>H256</td>\n",
+       "      <td>984</td>\n",
+       "      <td>12.696618</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>H381</td>\n",
+       "      <td>972</td>\n",
+       "      <td>12.271730</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>H381</td>\n",
+       "      <td>984</td>\n",
+       "      <td>49.347744</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>H413</td>\n",
+       "      <td>972</td>\n",
+       "      <td>23.099708</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>H413</td>\n",
+       "      <td>984</td>\n",
+       "      <td>17.449030</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  unique_id   ds  LGBMRegressor\n",
+       "0      H196  972      16.095804\n",
+       "1      H196  984      15.696618\n",
+       "2      H256  972      13.295804\n",
+       "3      H256  984      12.696618\n",
+       "4      H381  972      12.271730\n",
+       "5      H381  984      49.347744\n",
+       "6      H413  972      23.099708\n",
+       "7      H413  984      17.449030"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Train models only for horizons 12 and 24 (instead of all 1-24)\n",
+    "sparse_fcst = fcst.fit(train, horizons=[12, 24])\n",
+    "sparse_preds = sparse_fcst.predict(h=24)\n",
+    "\n",
+    "# Note: predictions are only returned for trained horizons\n",
+    "print(f\"Number of predictions per series: {len(sparse_preds) // sparse_preds['unique_id'].nunique()}\")\n",
+    "sparse_preds.head(8)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "itbuiptt07f",
+   "metadata": {},
+   "source": [
+    "Notice that with `horizons=[12, 24]`, the output only contains 2 predictions per series (at steps 12 and 24), not 24. This is the **sparse output** behavior - you only get predictions for the horizons you trained.\n",
+    "\n",
+    "### Partial predictions\n",
+    "\n",
+    "If you call `predict(h=N)` where `N` is less than some of your trained horizons, you'll only get predictions for horizons up to `N`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "zd663lga6c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of predictions per series: 1\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>unique_id</th>\n",
+       "      <th>ds</th>\n",
+       "      <th>LGBMRegressor</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>H196</td>\n",
+       "      <td>972</td>\n",
+       "      <td>16.095804</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>H256</td>\n",
+       "      <td>972</td>\n",
+       "      <td>13.295804</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>H381</td>\n",
+       "      <td>972</td>\n",
+       "      <td>12.271730</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>H413</td>\n",
+       "      <td>972</td>\n",
+       "      <td>23.099708</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  unique_id   ds  LGBMRegressor\n",
+       "0      H196  972      16.095804\n",
+       "1      H256  972      13.295804\n",
+       "2      H381  972      12.271730\n",
+       "3      H413  972      23.099708"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# With horizons=[12, 24], calling predict(h=15) only returns horizon 12\n",
+    "partial_preds = sparse_fcst.predict(h=15)\n",
+    "print(f\"Number of predictions per series: {len(partial_preds) // partial_preds['unique_id'].nunique()}\")\n",
+    "partial_preds.head(4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "rynrtd8skng",
+   "metadata": {},
+   "source": [
+    "### Cross-validation with specific horizons\n",
+    "\n",
+    "The `horizons` parameter also works with `cross_validation`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "butfdwoh4e8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CV results shape: (16, 5)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>unique_id</th>\n",
+       "      <th>ds</th>\n",
+       "      <th>cutoff</th>\n",
+       "      <th>y</th>\n",
+       "      <th>LGBMRegressor</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>H196</td>\n",
+       "      <td>924</td>\n",
+       "      <td>912</td>\n",
+       "      <td>22.7</td>\n",
+       "      <td>15.770231</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>H196</td>\n",
+       "      <td>936</td>\n",
+       "      <td>912</td>\n",
+       "      <td>16.4</td>\n",
+       "      <td>15.317588</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>H256</td>\n",
+       "      <td>924</td>\n",
+       "      <td>912</td>\n",
+       "      <td>17.9</td>\n",
+       "      <td>13.270231</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>H256</td>\n",
+       "      <td>936</td>\n",
+       "      <td>912</td>\n",
+       "      <td>13.3</td>\n",
+       "      <td>12.617588</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>H381</td>\n",
+       "      <td>924</td>\n",
+       "      <td>912</td>\n",
+       "      <td>166.0</td>\n",
+       "      <td>18.920395</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>H381</td>\n",
+       "      <td>936</td>\n",
+       "      <td>912</td>\n",
+       "      <td>50.0</td>\n",
+       "      <td>51.129478</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>H413</td>\n",
+       "      <td>924</td>\n",
+       "      <td>912</td>\n",
+       "      <td>45.0</td>\n",
+       "      <td>26.609079</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>H413</td>\n",
+       "      <td>936</td>\n",
+       "      <td>912</td>\n",
+       "      <td>31.0</td>\n",
+       "      <td>24.801567</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  unique_id   ds  cutoff      y  LGBMRegressor\n",
+       "0      H196  924     912   22.7      15.770231\n",
+       "1      H196  936     912   16.4      15.317588\n",
+       "2      H256  924     912   17.9      13.270231\n",
+       "3      H256  936     912   13.3      12.617588\n",
+       "4      H381  924     912  166.0      18.920395\n",
+       "5      H381  936     912   50.0      51.129478\n",
+       "6      H413  924     912   45.0      26.609079\n",
+       "7      H413  936     912   31.0      24.801567"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Cross-validation with specific horizons\n",
+    "cv_results = fcst.cross_validation(\n",
+    "    train,\n",
+    "    n_windows=2,\n",
+    "    h=24,\n",
+    "    horizons=[12, 24],\n",
+    ")\n",
+    "print(f\"CV results shape: {cv_results.shape}\")\n",
+    "cv_results.head(8)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qn4re5tzede",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "| Approach | Parameter | Use case |\n",
+    "|----------|-----------|----------|\n",
+    "| Recursive | (default) | General purpose, good when you need all horizons and want faster training |\n",
+    "| Direct (all horizons) | `max_horizon=N` | When you need predictions for all steps 1 to N and can afford training N models |\n",
+    "| Direct (specific horizons) | `horizons=[h1, h2, ...]` | When you only need predictions at specific steps (e.g., weekly/monthly forecasts) |\n",
+    "\n",
+    "Key points:\n",
+    "- `max_horizon` and `horizons` are mutually exclusive\n",
+    "- With `horizons`, the output only contains predictions for the specified horizons (sparse output)\n",
+    "- Both direct forecasting approaches work with `cross_validation` and exogenous features"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "python3",
+   "display_name": "mlforecast",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.14"
   }
  },
  "nbformat": 4,

--- a/tests/test_distributed_forecast.py
+++ b/tests/test_distributed_forecast.py
@@ -2,8 +2,10 @@ import sys
 import warnings
 
 import dask.dataframe as dd
+import numpy as np
 import pandas as pd
 import pytest
+from sklearn.base import BaseEstimator
 
 from mlforecast.distributed import DistributedMLForecast
 from mlforecast.distributed.models.dask.lgb import DaskLGBMForecast
@@ -12,21 +14,64 @@ from mlforecast.utils import generate_daily_series
 
 warnings.simplefilter("ignore", FutureWarning)
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Distributed tests are not supported on Windows")
-@pytest.mark.skipif(sys.version_info <= (3, 9), reason="Distributed tests are not supported on Python < 3.10")
-def test_dask_distributed_forecast():
+
+def _reset_index_partition(partition: pd.DataFrame) -> pd.DataFrame:
+    return partition.reset_index()
+
+
+def _make_partitioned_series(df: pd.DataFrame, npartitions: int = 4) -> dd.DataFrame:
+    partitioned = dd.from_pandas(df.set_index("unique_id"), npartitions=npartitions)
+    partitioned = partitioned.map_partitions(_reset_index_partition)
+    partitioned["unique_id"] = partitioned["unique_id"].astype(str)
+    return partitioned
+
+
+@pytest.fixture(scope="module")
+def partitioned_series():
     series = generate_daily_series(
         100, equal_ends=True, min_length=500, max_length=1_000
     )
-    npartitions = 4
-    partitioned_series = dd.from_pandas(
-        series.set_index("unique_id"), npartitions=npartitions
-    )  # make sure we split by the id_col
-    partitioned_series = partitioned_series.map_partitions(lambda df: df.reset_index())
-    partitioned_series["unique_id"] = partitioned_series["unique_id"].astype(
-        str
-    )  # can't handle categoricals atm
+    return _make_partitioned_series(series)
 
+
+@pytest.fixture
+def small_ordered_series():
+    series = generate_daily_series(5, min_length=60, max_length=60)
+    return series.sort_values(["unique_id", "ds"]).reset_index(drop=True)
+
+
+class _RecordingLocalModel:
+    def __init__(self, sample_weight):
+        if sample_weight is None:
+            self.sample_weight_ = None
+            self.weight_mean_ = 0.0
+        else:
+            self.sample_weight_ = np.asarray(sample_weight, dtype=float)
+            self.weight_mean_ = float(self.sample_weight_.mean())
+
+    def predict(self, X):
+        length = X.shape[0] if hasattr(X, "shape") else len(X)
+        return np.full(length, self.weight_mean_, dtype=float)
+
+
+class _RecordingDaskRegressor(BaseEstimator):
+    def fit(self, X, y, sample_weight=None):  # noqa: ARG002, D401, N803
+        if sample_weight is None:
+            weights = None
+        else:
+            if hasattr(sample_weight, "compute"):
+                sample_weight = sample_weight.compute()
+            weights = (
+                sample_weight.to_numpy()
+                if hasattr(sample_weight, "to_numpy")
+                else np.asarray(sample_weight, dtype=float)
+            )
+        self.model_ = _RecordingLocalModel(weights)
+        return self
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Distributed tests are not supported on Windows")
+@pytest.mark.skipif(sys.version_info <= (3, 9), reason="Distributed tests are not supported on Python < 3.10")
+def test_dask_distributed_forecast(partitioned_series):
     # test existing features provide the same result
     fcst = DistributedMLForecast(
         models=[DaskLGBMForecast(verbosity=-1, random_state=0)],
@@ -49,3 +94,33 @@ def test_dask_distributed_forecast():
     fcst.preprocess(partitioned_series, static_features=[], dropna=False)
     preds2 = fcst.predict(10).compute()
     pd.testing.assert_frame_equal(preds1, preds2)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Distributed tests are not supported on Windows")
+@pytest.mark.skipif(sys.version_info <= (3, 9), reason="Distributed tests are not supported on Python < 3.10")
+def test_dask_distributed_weight_col_affects_predictions(small_ordered_series):
+    def _fit_and_forecast(weights):
+        weighted = small_ordered_series.copy()
+        weighted["weight"] = weights
+        partitioned = _make_partitioned_series(weighted, npartitions=2)
+        fcst = DistributedMLForecast(
+            models={"stub": _RecordingDaskRegressor()},
+            freq="D",
+            lags=[1],
+            date_features=["dayofweek"],
+        )
+        fcst.fit(
+            partitioned,
+            static_features=[],
+            dropna=False,
+            weight_col="weight",
+        )
+        return fcst.predict(5).compute()
+
+    uniform_weights = np.ones(len(small_ordered_series))
+    skewed_weights = np.arange(len(small_ordered_series), dtype=float)
+
+    preds_uniform = _fit_and_forecast(uniform_weights)
+    preds_skewed = _fit_and_forecast(skewed_weights)
+
+    assert not np.allclose(preds_uniform["stub"], preds_skewed["stub"])

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -1007,3 +1007,435 @@ def test_direct_forecasting_perfect_exogenous_fit():
         rtol=1e-10,
         err_msg="Direct forecasting predictions do not match expected exogenous feature values"
     )
+
+
+@pytest.mark.parametrize("horizons", [
+    [1, 3],
+    [1, 3, 5, 7],
+    [1, 7],
+    [2, 4, 6],
+    [1, 2, 3],  # contiguous horizons
+])
+def test_direct_forecasting_perfect_exogenous_fit_with_horizons(horizons):
+    """Test that sparse horizons correctly use exogenous features for each trained horizon.
+
+    This test validates that when using the `horizons` parameter:
+    1. Predictions are only made for the specified horizons
+    2. Each horizon's prediction correctly uses its aligned exogenous features
+    3. The output timestamps (ds) are correct for the sparse horizons
+
+    With y = X (perfect linear relationship), predictions should equal the
+    exogenous feature values at the corresponding horizon timestamps.
+    """
+    max_h = max(horizons)
+    last_train_ds = 10
+
+    # Create training data where y = X (perfect linear relationship)
+    df = pd.DataFrame({
+        "ds": np.arange(last_train_ds + 1),
+        "X": np.arange(last_train_ds + 1),
+        "unique_id": "ex",
+        "y": np.arange(last_train_ds + 1),
+    })
+
+    # Create test dataframe with exogenous features for all possible prediction timestamps
+    test_df = pd.DataFrame({
+        "ds": np.arange(last_train_ds + 1, last_train_ds + 1 + max_h),
+        "X": np.arange(last_train_ds + 1, last_train_ds + 1 + max_h),
+        "unique_id": "ex",
+    })
+
+    # Fit with sparse horizons
+    fcst = MLForecast(
+        models=[LinearRegression()],
+        freq=1,
+    )
+    fcst.fit(df, static_features=[], horizons=horizons)
+
+    # Verify correct number of models trained
+    assert len(fcst.models_['LinearRegression']) == len(horizons)
+    # Models should be stored with 0-indexed keys
+    expected_keys = {h - 1 for h in horizons}
+    assert set(fcst.models_['LinearRegression'].keys()) == expected_keys
+
+    # Predict using exogenous features
+    preds = fcst.predict(h=max_h, X_df=test_df)
+
+    # Verify correct number of predictions (one per horizon)
+    assert preds.shape[0] == len(horizons)
+
+    # Verify timestamps are correct
+    expected_ds = [last_train_ds + h for h in horizons]
+    np.testing.assert_array_equal(
+        preds['ds'].values,
+        expected_ds,
+        err_msg=f"Timestamps mismatch for horizons={horizons}"
+    )
+
+    # Verify predictions equal the exogenous feature values at the correct timestamps
+    # For y = X, prediction at ds=t should equal X[t] = t
+    expected_values = np.array(expected_ds, dtype=float)
+    np.testing.assert_allclose(
+        preds['LinearRegression'].values,
+        expected_values,
+        rtol=1e-10,
+        err_msg=f"Predictions do not match expected values for horizons={horizons}"
+    )
+
+
+def test_direct_forecasting_perfect_exogenous_fit_horizons_vs_max_horizon():
+    """Test that horizons=[1,2,3] produces identical results to max_horizon=3.
+
+    This validates that the new horizons parameter, when given contiguous horizons,
+    produces the same predictions as the equivalent max_horizon parameter.
+    """
+    last_train_ds = 10
+    H = 5
+
+    # Create training data where y = X
+    df = pd.DataFrame({
+        "ds": np.arange(last_train_ds + 1),
+        "X": np.arange(last_train_ds + 1),
+        "unique_id": "ex",
+        "y": np.arange(last_train_ds + 1),
+    })
+
+    # Create test dataframe
+    test_df = pd.DataFrame({
+        "ds": np.arange(last_train_ds + 1, last_train_ds + 1 + H),
+        "X": np.arange(last_train_ds + 1, last_train_ds + 1 + H),
+        "unique_id": "ex",
+    })
+
+    # Fit with max_horizon
+    fcst_max = MLForecast(models=[LinearRegression()], freq=1)
+    fcst_max.fit(df, static_features=[], max_horizon=H)
+    preds_max = fcst_max.predict(h=H, X_df=test_df)
+
+    # Fit with equivalent horizons
+    fcst_horizons = MLForecast(models=[LinearRegression()], freq=1)
+    fcst_horizons.fit(df, static_features=[], horizons=list(range(1, H + 1)))
+    preds_horizons = fcst_horizons.predict(h=H, X_df=test_df)
+
+    # Results should be identical
+    pd.testing.assert_frame_equal(preds_max, preds_horizons)
+
+
+def test_direct_forecasting_perfect_exogenous_fit_multiple_series():
+    """Test sparse horizons with multiple time series.
+
+    Validates that sparse horizons work correctly when forecasting multiple series,
+    with correct timestamps and predictions for each series.
+    """
+    horizons = [1, 3, 5]
+    max_h = max(horizons)
+    n_series = 5
+
+    # Generate series structure using generate_daily_series
+    df = generate_daily_series(n_series, min_length=20, max_length=20, equal_ends=True)
+
+    # Add exogenous feature X and set y = X for perfect linear relationship
+    # Use cumcount within each series to create unique X values
+    df = df.sort_values(['unique_id', 'ds']).reset_index(drop=True)
+    df['X'] = df.groupby('unique_id', observed=True).cumcount().astype(float)
+    df['y'] = df['X']
+
+    # Fit with sparse horizons
+    fcst = MLForecast(models=[LinearRegression()], freq='D')
+    fcst.fit(df, static_features=[], horizons=horizons)
+
+    # Create future dataframe using make_future_dataframe
+    future_df = fcst.make_future_dataframe(h=max_h)
+
+    # Add exogenous feature X to future dataframe
+    # X continues from where training left off (20, 21, 22, ...)
+    last_train_idx = df.groupby('unique_id', observed=True)['X'].transform('max')
+    future_df = future_df.sort_values(['unique_id', 'ds']).reset_index(drop=True)
+    future_df['X'] = future_df.groupby('unique_id', observed=True).cumcount() + 20.0
+
+    preds = fcst.predict(h=max_h, X_df=future_df)
+
+    # Should have len(horizons) predictions per series
+    assert preds.shape[0] == n_series * len(horizons)
+
+    # Get last dates from training data
+    last_dates = df.groupby('unique_id', observed=True)['ds'].max()
+
+    # Verify each series has correct predictions
+    for uid in df['unique_id'].unique():
+        series_preds = preds[preds['unique_id'] == uid].sort_values('ds')
+        assert series_preds.shape[0] == len(horizons)
+
+        # Verify timestamps are correct for sparse horizons
+        expected_dates = [last_dates[uid] + pd.Timedelta(days=h) for h in horizons]
+        assert series_preds['ds'].tolist() == expected_dates
+
+        # Verify predictions match expected X values (y = X)
+        # X values at horizons [1, 3, 5] are [20, 22, 24] (0-indexed from end of training)
+        expected_values = np.array([20 + h - 1 for h in horizons], dtype=float)
+        np.testing.assert_allclose(
+            series_preds['LinearRegression'].values,
+            expected_values,
+            rtol=1e-10
+        )
+
+
+# Tests for horizons parameter
+def test_horizons_basic():
+    """Test that horizons=[7, 14] creates exactly 2 models."""
+    df = generate_daily_series(10, min_length=50, max_length=100)
+    fcst = MLForecast(
+        models=[LinearRegression()],
+        freq='D',
+        lags=[1, 7],
+    )
+    fcst.fit(df, horizons=[7, 14])
+
+    # Verify only 2 models trained per model name
+    assert len(fcst.models_['LinearRegression']) == 2
+    # Models are stored as dict keyed by 0-indexed horizon
+    assert set(fcst.models_['LinearRegression'].keys()) == {6, 13}
+
+
+def test_horizons_mutual_exclusivity():
+    """Test error when both max_horizon and horizons provided."""
+    df = generate_daily_series(10, min_length=50, max_length=100)
+    fcst = MLForecast(
+        models=[LinearRegression()],
+        freq='D',
+        lags=[1, 7],
+    )
+    with pytest.raises(ValueError, match="Cannot specify both"):
+        fcst.fit(df, max_horizon=5, horizons=[7, 14])
+
+
+def test_horizons_validation_empty():
+    """Test error for empty horizons list."""
+    df = generate_daily_series(10, min_length=50, max_length=100)
+    fcst = MLForecast(
+        models=[LinearRegression()],
+        freq='D',
+        lags=[1, 7],
+    )
+    with pytest.raises(ValueError, match="cannot be empty"):
+        fcst.fit(df, horizons=[])
+
+
+def test_horizons_validation_non_positive():
+    """Test error for non-positive horizons."""
+    df = generate_daily_series(10, min_length=50, max_length=100)
+    fcst = MLForecast(
+        models=[LinearRegression()],
+        freq='D',
+        lags=[1, 7],
+    )
+    with pytest.raises(ValueError, match="positive integers"):
+        fcst.fit(df, horizons=[0, 7, 14])
+
+    with pytest.raises(ValueError, match="positive integers"):
+        fcst.fit(df, horizons=[-1, 7])
+
+
+def test_horizons_validation_non_integer():
+    """Test error for non-integer horizons."""
+    df = generate_daily_series(10, min_length=50, max_length=100)
+    fcst = MLForecast(
+        models=[LinearRegression()],
+        freq='D',
+        lags=[1, 7],
+    )
+    with pytest.raises(ValueError, match="positive integers"):
+        fcst.fit(df, horizons=[7.5, 14])
+
+
+def test_horizons_duplicate_handling():
+    """Test that horizons=[7, 7, 14] deduplicates to [7, 14]."""
+    df = generate_daily_series(10, min_length=50, max_length=100)
+    fcst = MLForecast(
+        models=[LinearRegression()],
+        freq='D',
+        lags=[1, 7],
+    )
+    fcst.fit(df, horizons=[7, 7, 14, 14])
+
+    # Should have exactly 2 models after deduplication
+    assert len(fcst.models_['LinearRegression']) == 2
+    assert set(fcst.models_['LinearRegression'].keys()) == {6, 13}
+
+
+def test_horizons_prediction():
+    """Test that predict(h=14) with horizons=[7, 14] works correctly."""
+    df = generate_daily_series(10, min_length=50, max_length=100)
+    fcst = MLForecast(
+        models=[LinearRegression()],
+        freq='D',
+        lags=[1, 7],
+    )
+    fcst.fit(df, horizons=[7, 14])
+
+    # Predict for horizon 14
+    preds = fcst.predict(h=14)
+
+    # Should only have predictions for the trained horizons (7 and 14)
+    # Each series gets 2 predictions
+    n_series = df['unique_id'].nunique()
+    assert preds.shape[0] == n_series * 2
+
+    # Check that dates are correct (at h=7 and h=14 from last date)
+    last_dates = df.groupby('unique_id', observed=True)['ds'].max()
+    for uid in df['unique_id'].unique():
+        uid_preds = preds[preds['unique_id'] == uid]
+        expected_dates = [
+            last_dates[uid] + pd.Timedelta(days=7),
+            last_dates[uid] + pd.Timedelta(days=14),
+        ]
+        assert uid_preds['ds'].tolist() == expected_dates
+
+
+def test_horizons_prediction_partial():
+    """Test that predict(h=10) with horizons=[7, 14] only returns h=7."""
+    df = generate_daily_series(10, min_length=50, max_length=100)
+    fcst = MLForecast(
+        models=[LinearRegression()],
+        freq='D',
+        lags=[1, 7],
+    )
+    fcst.fit(df, horizons=[7, 14])
+
+    # Predict for horizon 10 (only h=7 is available)
+    preds = fcst.predict(h=10)
+
+    # Should only have predictions for h=7
+    n_series = df['unique_id'].nunique()
+    assert preds.shape[0] == n_series * 1
+
+
+def test_horizons_cross_validation():
+    """Test that cross_validation works with sparse horizons parameter.
+
+    Note: With sparse horizons, predictions are only made for trained horizons,
+    so the CV result will have fewer rows than the validation set. The join
+    filters to only matching timestamps.
+    """
+    df = generate_daily_series(10, min_length=100, max_length=150)
+    fcst = MLForecast(
+        models=[LinearRegression()],
+        freq='D',
+        lags=[1, 7],
+    )
+
+    # Use max_horizon=14 which is equivalent to horizons=[1,2,...,14]
+    # This should work the same as before
+    cv_results = fcst.cross_validation(
+        df,
+        n_windows=2,
+        h=14,
+        max_horizon=14,
+    )
+
+    # Should have predictions for all 14 horizons per series per window
+    assert cv_results.shape[0] > 0
+    assert 'LinearRegression' in cv_results.columns
+
+
+def test_horizons_backward_compatibility():
+    """Test that max_horizon=5 works identically to before."""
+    df = generate_daily_series(10, min_length=50, max_length=100)
+
+    # Fit with max_horizon
+    fcst1 = MLForecast(
+        models=[LinearRegression()],
+        freq='D',
+        lags=[1, 7],
+    )
+    fcst1.fit(df, max_horizon=5)
+    preds1 = fcst1.predict(h=5)
+
+    # Models should be stored as dict with keys 0, 1, 2, 3, 4
+    assert isinstance(fcst1.models_['LinearRegression'], dict)
+    assert set(fcst1.models_['LinearRegression'].keys()) == {0, 1, 2, 3, 4}
+
+    # Predictions should have 5 rows per series
+    n_series = df['unique_id'].nunique()
+    assert preds1.shape[0] == n_series * 5
+
+
+def test_horizons_with_exogenous():
+    """Test horizons with exogenous features."""
+    df = generate_daily_series(5, min_length=50, max_length=60)
+    df['exog'] = np.random.randn(len(df))
+
+    fcst = MLForecast(
+        models=[LinearRegression()],
+        freq='D',
+        lags=[1, 7],
+    )
+    fcst.fit(df, horizons=[7, 14], static_features=[])
+
+    # Create future exogenous
+    future_df = fcst.make_future_dataframe(h=14)
+    future_df['exog'] = np.random.randn(len(future_df))
+
+    preds = fcst.predict(h=14, X_df=future_df)
+    assert preds.shape[0] > 0
+
+
+def test_horizons_with_target_transforms():
+    """Test that sparse horizons work correctly with target transforms.
+
+    This is a regression test for the bug where inverse_transform failed
+    because indptr was computed using the requested horizon instead of
+    the actual number of predictions (output_horizon).
+    """
+    from mlforecast.target_transforms import Differences
+
+    df = generate_daily_series(5, min_length=50, max_length=60)
+
+    fcst = MLForecast(
+        models=[LinearRegression()],
+        freq='D',
+        lags=[1, 7, 14],
+        target_transforms=[Differences([7])],
+    )
+    fcst.fit(df, horizons=[7, 14])
+
+    # This should not raise an error about indptr/data size mismatch
+    preds = fcst.predict(h=14)
+
+    # Should have 2 predictions per series (h=7 and h=14)
+    n_series = df['unique_id'].nunique()
+    assert preds.shape[0] == n_series * 2
+
+
+def test_horizons_cross_validation_with_target_transforms():
+    """Test cross_validation with sparse horizons and target transforms.
+
+    This is a regression test for the bug where cross_validation failed
+    with sparse horizons because:
+    1. inverse_transform used wrong indptr size
+    2. result row count check didn't account for sparse output
+    """
+    from mlforecast.target_transforms import Differences
+
+    df = generate_daily_series(5, min_length=100, max_length=120)
+
+    fcst = MLForecast(
+        models=[LinearRegression()],
+        freq='D',
+        lags=[1, 7, 14],
+        target_transforms=[Differences([7])],
+    )
+
+    # This should not raise any errors
+    cv_results = fcst.cross_validation(
+        df,
+        n_windows=2,
+        h=14,
+        horizons=[7, 14],
+    )
+
+    # Should have 2 predictions per series per window
+    n_series = df['unique_id'].nunique()
+    n_windows = 2
+    n_horizons = 2  # [7, 14]
+    assert cv_results.shape[0] == n_series * n_windows * n_horizons


### PR DESCRIPTION
## Description
Adds support to include sample weights through the `weight_col` parameter in the relevant methods of `DistributedMLForecast` (fit, cross_validation).

Does not support Ray at this time, only Spark and Dask.

Passes existing and new tests that are included in `tests/test_distributed_forecast.py`

Checklist:
- [x] This PR has a meaningful title and a clear description.
- [x] The tests pass.
- [x] All linting tasks pass.
- [x] The notebooks are clean.