### PR TITLE
[FEAT] Automatic Thread Count

### DIFF
--- a/mlforecast/auto.py
+++ b/mlforecast/auto.py
@@ -26,7 +26,7 @@ from . import MLForecast
 from .core import Freq, _get_model_name, _name_models
 from .lag_transforms import ExponentiallyWeightedMean, RollingMean
 from .optimization import _TrialToConfig, mlforecast_objective
-from .utils import PredictionIntervals
+from .utils import PredictionIntervals, _resolve_num_threads
 
 
 def lightgbm_space(trial: optuna.Trial):
@@ -243,7 +243,7 @@ class AutoMLForecast:
             Defaults to None.
         fit_config (callable, optional): Function that takes an optuna trial and produces a configuration passed to the MLForecast fit method.
             Defaults to None.
-        num_threads (int): Number of threads to use when computing the features. Defaults to 1.
+        num_threads (int): Number of threads to use when computing the features. Use -1 to use all available CPU cores. Defaults to 1.
         reuse_cv_splits (bool): Creates splits for cv once and re-uses them for tuning instead of generating the splits in each tuning round.
             Default is set to False.
     """
@@ -275,6 +275,7 @@ class AutoMLForecast:
             self.fit_config = fit_config
         else:
             self.fit_config = lambda trial: {}  # noqa: ARG005
+        num_threads = _resolve_num_threads(num_threads)
         self.num_threads = num_threads
         if isinstance(models, list):
             model_names = _name_models([_get_model_name(m) for m in models])

--- a/mlforecast/core.py
+++ b/mlforecast/core.py
@@ -45,7 +45,7 @@ from mlforecast.target_transforms import (
 
 from .grouped_array import GroupedArray
 from .lag_transforms import Lag, _BaseLagTransform
-from .utils import _ShortSeriesException
+from .utils import _ShortSeriesException, _resolve_num_threads
 
 date_features_dtypes = {
     "year": np.uint16,
@@ -210,6 +210,7 @@ class TimeSeries:
         lag_transforms_namer: Optional[Callable] = None,
     ):
         self.freq = freq
+        num_threads = _resolve_num_threads(num_threads)
         if not isinstance(num_threads, int) or num_threads < 1:
             warnings.warn("Setting num_threads to 1.")
             num_threads = 1

--- a/mlforecast/distributed/forecast.py
+++ b/mlforecast/distributed/forecast.py
@@ -50,6 +50,7 @@ from mlforecast.core import (
 
 from ..forecast import MLForecast
 from ..grouped_array import GroupedArray
+from ..utils import _resolve_num_threads
 
 WindowInfo = namedtuple(
     "WindowInfo", ["n_windows", "window_size", "step_size", "i_window", "input_size"]
@@ -81,7 +82,7 @@ class DistributedMLForecast:
             lag_transforms (dict of int to list of functions, optional): Mapping of target lags to their transformations. Defaults to None.
             date_features (list of str or callable, optional): Features computed from the dates. Can be pandas date attributes or functions that will take the dates as input.
                 Defaults to None.
-            num_threads (int): Number of threads to use when computing the features. Defaults to 1.
+            num_threads (int): Number of threads to use when computing the features. Use -1 to use all available CPU cores. Defaults to 1.
             target_transforms (list of transformers, optional): Transformations that will be applied to the target before computing the features and restored after the forecasting step.
                 Defaults to None.
             engine (fugue execution engine, optional): Dask Client, Spark Session, etc to use for the distributed computation.
@@ -108,6 +109,7 @@ class DistributedMLForecast:
                 return name.replace(".", "_")
 
             lag_transforms_namer = name_without_dots
+        num_threads = _resolve_num_threads(num_threads)
         self._base_ts = TimeSeries(
             freq=freq,
             lags=lags,

--- a/mlforecast/feature_engineering.py
+++ b/mlforecast/feature_engineering.py
@@ -9,6 +9,7 @@ from utilsforecast.validation import validate_format
 
 from .core import Lags, LagTransforms, _parse_transforms
 from .grouped_array import GroupedArray
+from .utils import _resolve_num_threads
 
 
 def transform_exog(
@@ -27,11 +28,12 @@ def transform_exog(
         lag_transforms (dict of int to list of functions, optional): Mapping of target lags to their transformations. Defaults to None.
         id_col (str): Column that identifies each serie. Defaults to 'unique_id'.
         time_col (str): Column that identifies each timestep, its values can be timestamps or integers. Defaults to 'ds'.
-        num_threads (int): Number of threads to use when computing the features. Defaults to 1.
+        num_threads (int): Number of threads to use when computing the features. Use -1 to use all available CPU cores. Defaults to 1.
 
     Returns:
         (pandas or polars DataFrame): Original DataFrame with the computed features
     """
+    num_threads = _resolve_num_threads(num_threads)
     if lags is None and lag_transforms is None:
         raise ValueError("At least one of `lags` or `lag_transforms` is required.")
     if lags is None:

--- a/mlforecast/forecast.py
+++ b/mlforecast/forecast.py
@@ -42,7 +42,7 @@ from .grouped_array import GroupedArray
 if TYPE_CHECKING:
     from mlforecast.lgb_cv import LightGBMCV
 from .target_transforms import _BaseGroupedArrayTargetTransform
-from .utils import PredictionIntervals
+from .utils import PredictionIntervals, _resolve_num_threads
 
 
 def _add_conformal_distribution_intervals(
@@ -152,7 +152,7 @@ class MLForecast:
             lags (list of int, optional): Lags of the target to use as features. Defaults to None.
             lag_transforms (dict of int to list of functions, optional): Mapping of target lags to their transformations. Defaults to None.
             date_features (list of str or callable, optional): Features computed from the dates. Can be pandas date attributes or functions that will take the dates as input. Defaults to None.
-            num_threads (int): Number of threads to use when computing the features. Defaults to 1.
+            num_threads (int): Number of threads to use when computing the features. Use -1 to use all available CPU cores. Defaults to 1.
             target_transforms (list of transformers, optional): Transformations that will be applied to the target before computing the features and restored after the forecasting step. Defaults to None.
             lag_transforms_namer (callable, optional): Function that takes a transformation (either function or class), a lag and extra arguments and produces a name. Defaults to None.
         """
@@ -164,6 +164,7 @@ class MLForecast:
         else:
             models_with_names = models
         self.models = models_with_names
+        num_threads = _resolve_num_threads(num_threads)
         self.ts = TimeSeries(
             freq=freq,
             lags=lags,

--- a/mlforecast/lgb_cv.py
+++ b/mlforecast/lgb_cv.py
@@ -21,6 +21,7 @@ from mlforecast.core import (
     TargetTransform,
     TimeSeries,
 )
+from mlforecast.utils import _resolve_num_threads
 
 
 def _mape(y_true, y_pred, ids, _dates, weight_series=None):
@@ -117,10 +118,11 @@ class LightGBMCV:
             lag_transforms (dict of int to list of functions, optional): Mapping of target lags to their transformations. Defaults to None.
             date_features (list of str or callable, optional): Features computed from the dates. Can be pandas date attributes or functions that will take the dates as input.
                 Defaults to None.
-            num_threads (int): Number of threads to use when computing the features. Defaults to 1.
+            num_threads (int): Number of threads to use when computing the features. Use -1 to use all available CPU cores. Defaults to 1.
             target_transforms (list of transformers, optional): Transformations that will be applied to the target before computing the features and restored after the forecasting step.
                 Defaults to None.
         """
+        num_threads = _resolve_num_threads(num_threads)
         self.num_threads = num_threads
         cpu_count = os.cpu_count()
         if cpu_count is None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1936,3 +1936,30 @@ def test_target_nulls(series):
     )
     prep = ts.fit_transform(series, "unique_id", "ds", "y", dropna=False)
     assert not prep["y"].isnull().any()
+
+
+def test_timeseries_num_threads_minus_one(series):
+    """Test that TimeSeries correctly handles num_threads=-1."""
+    from joblib import cpu_count
+
+    ts = TimeSeries(
+        freq="D",
+        lags=[1, 2],
+        num_threads=-1,
+    )
+    assert ts.num_threads == cpu_count()
+    assert ts.num_threads >= 1
+
+    # Verify it works in fit_transform and produces same results as num_threads=1
+    prep_multi = ts.fit_transform(series, "unique_id", "ds", "y")
+    assert prep_multi is not None
+
+    # Compare with num_threads=1
+    ts_single = TimeSeries(
+        freq="D",
+        lags=[1, 2],
+        num_threads=1,
+    )
+    prep_single = ts_single.fit_transform(series, "unique_id", "ds", "y")
+
+    pd.testing.assert_frame_equal(prep_multi, prep_single)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,10 @@
-import pytest
+import warnings
+from unittest.mock import patch
 
-from mlforecast.utils import generate_daily_series, generate_prices_for_series
+import pytest
+from joblib import cpu_count
+
+from mlforecast.utils import generate_daily_series, generate_prices_for_series, _resolve_num_threads
 
 from .conftest import assert_raises_with_message
 
@@ -44,3 +48,37 @@ def test_generate_daily_series_equal_ends(setup):
 
     assert set(prices_catalog["unique_id"]) == set(series_for_prices["unique_id"])
     assert_raises_with_message(lambda: generate_prices_for_series(series), "equal ends")
+
+
+def test_resolve_num_threads_minus_one():
+    """Test that num_threads=-1 converts to actual CPU count."""
+    resolved = _resolve_num_threads(-1)
+    expected = cpu_count()
+    assert resolved == expected
+    assert isinstance(resolved, int)
+    assert resolved >= 1
+
+
+def test_resolve_num_threads_cpu_count_returns_none():
+    """Test fallback when joblib.cpu_count() returns None."""
+    with patch('mlforecast.utils.cpu_count', return_value=None):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = _resolve_num_threads(-1)
+            assert result == 1
+            assert len(w) == 1
+            assert "Could not determine CPU count" in str(w[0].message)
+            assert issubclass(w[0].category, UserWarning)
+
+
+def test_resolve_num_threads_cpu_count_raises_exception():
+    """Test fallback when joblib.cpu_count() raises an exception."""
+    with patch('mlforecast.utils.cpu_count', side_effect=RuntimeError("Test error")):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = _resolve_num_threads(-1)
+            assert result == 1
+            assert len(w) == 1
+            assert "Error determining CPU count" in str(w[0].message)
+            assert "Test error" in str(w[0].message)
+            assert issubclass(w[0].category, UserWarning)


### PR DESCRIPTION
Add support for num_threads=-1 to use all available CPU cores                                                                 
 
Closes #482 
                                                                                                                          
## Summary                                                                                                                       
                                                                                                                                
Implements num_threads=-1 to automatically utilize all available CPU cores via joblib.cpu_count(). This enhancement maintains backward compatibility (default remains 1) and centralizes the conversion logic in a single utility function.                 
                                                                                                                                
## Changes                                                                                                                       
                                                                                                                                
  - New utility function: _resolve_num_threads() in mlforecast/utils.py                                                         
    - Converts -1 to actual CPU count using joblib.cpu_count()                                                                  
    - Respects Docker/Kubernetes CPU limits and CPU affinity                                                                    
    - Graceful fallback to num_threads=1 with warnings on errors                                                                
  - Updated modules (7 total):                                                                                                  
    - mlforecast/core.py (TimeSeries)                                                                                           
    - mlforecast/forecast.py (MLForecast)                                                                                       
    - mlforecast/distributed/forecast.py (DistributedMLForecast)                                                                
    - mlforecast/auto.py (AutoMLForecast)                                                                                       
    - mlforecast/lgb_cv.py (LightGBMCV)                                                                                         
    - mlforecast/feature_engineering.py (transform_exog)                                                                        
    - All docstrings updated to document the new feature 
    
 ## Testing                                                                                
                                                                                                                               
  - Unit tests for _resolve_num_threads()                                                    
  - Integration tests verify num_threads=-1 produces identical results to num_threads=1                                         
  - All existing tests pass without regressions 