### PR TITLE
[FIX] #458 warn on timestamp gaps (best-effort, backend-safe)

### DIFF
--- a/mlforecast/core.py
+++ b/mlforecast/core.py
@@ -292,6 +292,57 @@ class TimeSeries:
                 "Global and group lag transforms require all series to end at the same timestamp."
             )
 
+    def _warn_gaps(self, bad_ids: List[Any]) -> None:
+        max_ids_to_show = 10
+        shown_ids = bad_ids[:max_ids_to_show]
+        extra = len(bad_ids) - len(shown_ids)
+        if extra > 0:
+            ids_msg = f"{shown_ids} (+{extra} more)"
+        else:
+            ids_msg = str(shown_ids)
+        warnings.warn(
+            f"The following series have gaps (missing timestamps): {ids_msg}. "
+            "This means that lag features will be computed based on positional "
+            "order rather than temporal order, which may produce incorrect results. "
+            "Consider filling the gaps in your data before fitting.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+    def _check_gaps(self, sorted_df: DataFrame) -> None:
+        """Warn if any series have gaps (missing timestamps)."""
+        if isinstance(sorted_df, pd.DataFrame):
+            try:
+                expected_next = ufp.offset_times(sorted_df[self.time_col], self.freq, 1)
+            except Exception:
+                # Gap checks are best-effort diagnostics and must not break fit.
+                return
+            next_time = sorted_df.groupby(
+                self.id_col, observed=True
+            )[self.time_col].shift(-1)
+            gaps = next_time.notna() & (expected_next != next_time)
+            if gaps.any():
+                bad_ids = sorted_df.loc[gaps, self.id_col].unique().tolist()
+                self._warn_gaps(bad_ids)
+        elif pl is not None and isinstance(sorted_df, pl.DataFrame):
+            try:
+                expected_next = ufp.offset_times(sorted_df[self.time_col], self.freq, 1)
+            except Exception:
+                # Gap checks are best-effort diagnostics and must not break fit.
+                return
+            df_check = sorted_df.with_columns(
+                pl.Series(name="_expected_next", values=expected_next)
+            ).with_columns(
+                pl.col(self.time_col).shift(-1).over(self.id_col).alias("_next")
+            )
+            gaps = df_check.filter(
+                pl.col("_next").is_not_null()
+                & (pl.col("_expected_next") != pl.col("_next"))
+            )
+            if gaps.height:
+                bad_ids = gaps[self.id_col].unique().to_list()
+                self._warn_gaps(bad_ids)
+
     @property
     def _date_feature_names(self):
         return [f.__name__ if callable(f) else f for f in self.date_features]
@@ -366,6 +417,7 @@ class TimeSeries:
             sorted_df = ufp.take_rows(sorted_df, self._sort_idxs)
         else:
             self._restore_idxs = None
+        self._check_gaps(sorted_df)
         if self.target_transforms is not None:
             for tfm in self.target_transforms:
                 if isinstance(tfm, _BaseGroupedArrayTargetTransform):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1963,3 +1963,89 @@ def test_timeseries_num_threads_minus_one(series):
     prep_single = ts_single.fit_transform(series, "unique_id", "ds", "y")
 
     pd.testing.assert_frame_equal(prep_multi, prep_single)
+
+
+@pytest.mark.parametrize(
+    "engine, freq",
+    [
+        ("pandas", "D"),
+        ("polars", "1d"),
+    ],
+)
+def test_check_gaps_warns_with_datetime(engine, freq):
+    """Test that fitting with gaps in datetime series triggers a warning."""
+    series = generate_daily_series(2, min_length=10, max_length=10, engine=engine)
+    # Drop one row from the first series to create a gap
+    if engine == "pandas":
+        series = series.drop(series.index[3]).reset_index(drop=True)
+    else:
+        mask = [True] * series.height
+        mask[3] = False
+        series = series.filter(pl.Series(mask))
+    ts = TimeSeries(freq=freq, lags=[1])
+    with pytest.warns(UserWarning, match="gaps"):
+        ts.fit_transform(series, id_col="unique_id", time_col="ds", target_col="y")
+
+
+@pytest.mark.parametrize("engine, freq", [("pandas", "D"), ("polars", "1d")])
+def test_check_gaps_no_warning_clean_data(engine, freq):
+    """Test that fitting with clean data does not trigger a gap warning."""
+    series = generate_daily_series(2, min_length=10, max_length=10, engine=engine)
+    ts = TimeSeries(freq=freq, lags=[1])
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        ts.fit_transform(series, id_col="unique_id", time_col="ds", target_col="y")
+
+
+def test_check_gaps_integer_timestamps():
+    """Test gap detection with integer timestamps."""
+    df = pd.DataFrame(
+        {
+            "unique_id": ["a"] * 5,
+            "ds": [1, 2, 3, 5, 6],  # gap at 4
+            "y": [10, 20, 30, 40, 50],
+        }
+    )
+    ts = TimeSeries(freq=1, lags=[1])
+    with pytest.warns(UserWarning, match="gaps"):
+        ts.fit_transform(df, id_col="unique_id", time_col="ds", target_col="y")
+
+
+@pytest.mark.parametrize("engine, freq", [("pandas", "D"), ("polars", "1d")])
+def test_check_gaps_identifies_correct_series(engine, freq):
+    """Test that the warning identifies only the series with gaps."""
+    series = generate_daily_series(3, min_length=10, max_length=10, engine=engine)
+    # Identify the second series and remove one row to create a gap
+    if engine == "pandas":
+        uid = series["unique_id"].unique()[1]
+        mask = series["unique_id"] == uid
+        idx = series[mask].index[3]
+        series = series.drop(idx).reset_index(drop=True)
+    else:
+        uid = series["unique_id"].unique().to_list()[1]
+        row_indices = list(range(series.height))
+        uid_rows = [
+            i for i in row_indices if series["unique_id"][i] == uid
+        ]
+        drop_idx = uid_rows[3]
+        mask = [True] * series.height
+        mask[drop_idx] = False
+        series = series.filter(pl.Series(mask))
+    ts = TimeSeries(freq=freq, lags=[1])
+    with pytest.warns(UserWarning, match=str(uid)):
+        ts.fit_transform(series, id_col="unique_id", time_col="ds", target_col="y")
+
+
+def test_check_gaps_warning_truncates_long_id_list():
+    """Test that warning message truncates id list when many series have gaps."""
+    n_ids = 12
+    df = pd.DataFrame(
+        {
+            "unique_id": [f"id_{i}" for i in range(n_ids) for _ in range(2)],
+            "ds": [1, 3] * n_ids,
+            "y": np.arange(2 * n_ids),
+        }
+    )
+    ts = TimeSeries(freq=1, lags=[1])
+    with pytest.warns(UserWarning, match=r"\(\+\d+ more\)"):
+        ts.fit_transform(df, id_col="unique_id", time_col="ds", target_col="y")


### PR DESCRIPTION
## Summary
- Add gap diagnostics in `TimeSeries._fit` via `_check_gaps`/`_warn_gaps`.
- Warn with truncated id lists and `stacklevel=2` for actionable messages.
- Make gap checks best-effort (do not break fit if backend-specific dtype/freq offseting fails).
- Add tests for datetime/integer gaps, clean data, id-specific warnings, and truncation behavior.

## Why
Users can silently compute lag features over positional order when timestamps have gaps. This adds explicit warnings without making fitting brittle.

## Tests
- `/home/welink/dev/work/Nixtla/mlforecast/.venv/bin/pytest --no-cov tests/test_core.py -k check_gaps -vv`

Closes #458