### PR TITLE
[FIX][DOCS] #315 date feature compatibility and explicit docs

### DIFF
--- a/docs/core.html.md
+++ b/docs/core.html.md
@@ -117,6 +117,26 @@ The date features are stored as they were passed to the constructor.
 test_eq(ts.date_features, flow_config['date_features'])
 ```
 
+Supported built-in string date features (for pandas and polars) are:
+
+* `year`
+* `month`
+* `day`
+* `hour`
+* `minute`
+* `second`
+* `dayofyear`, `day_of_year`
+* `week`, `weekofyear`
+* `dayofweek`, `day_of_week`, `weekday`
+* `quarter`
+* `daysinmonth`
+* `is_month_start`, `is_month_end`
+* `is_quarter_start`, `is_quarter_end`
+* `is_year_start`, `is_year_end`
+
+For broad compatibility across pandas versions/backends, prefer `week`
+over `weekofyear` and `dayofyear` over `day_of_year`.
+
 The transformations are stored as a dictionary where the key is the name
 of the transformation (name of the column in the dataframe with the
 computed features), which is built using `build_transform_name` and the

--- a/mlforecast/core.py
+++ b/mlforecast/core.py
@@ -543,12 +543,96 @@ class TimeSeries:
             feat_vals = feature(dates)
         else:
             feat_name = feature
-            if isinstance(dates, pd.DatetimeIndex):
-                if feature in ("week", "weekofyear"):
-                    dates = dates.isocalendar()
-                feat_vals = getattr(dates, feature)
-            else:
-                feat_vals = getattr(dates.dt, feature)()
+            supported = sorted(date_features_dtypes.keys())
+            try:
+                if isinstance(dates, pd.DatetimeIndex):
+                    pandas_feature = {
+                        "day_of_year": "dayofyear",
+                        "day_of_week": "dayofweek",
+                    }.get(feature, feature)
+                    if feature in ("week", "weekofyear"):
+                        feat_vals = dates.isocalendar().week
+                    else:
+                        feat_vals = getattr(dates, pandas_feature)
+                elif isinstance(dates, pd.Series):
+                    pandas_feature = {
+                        "day_of_year": "dayofyear",
+                        "day_of_week": "dayofweek",
+                    }.get(feature, feature)
+                    if feature in ("week", "weekofyear"):
+                        feat_vals = dates.dt.isocalendar().week
+                    else:
+                        accessor = getattr(dates.dt, pandas_feature)
+                        feat_vals = accessor() if callable(accessor) else accessor
+                elif pl is not None and isinstance(dates, pl.Expr):
+                    polars_feature = {
+                        "dayofyear": "ordinal_day",
+                        "day_of_year": "ordinal_day",
+                        "weekofyear": "week",
+                        "dayofweek": "weekday",
+                        "day_of_week": "weekday",
+                    }.get(feature, feature)
+                    if polars_feature == "daysinmonth":
+                        feat_vals = dates.dt.month_end().dt.day()
+                    elif polars_feature == "is_month_start":
+                        feat_vals = dates == dates.dt.month_start()
+                    elif polars_feature == "is_month_end":
+                        feat_vals = dates == dates.dt.month_end()
+                    elif polars_feature == "is_quarter_start":
+                        feat_vals = dates.dt.month().is_in([1, 4, 7, 10]) & (
+                            dates.dt.day() == 1
+                        )
+                    elif polars_feature == "is_quarter_end":
+                        feat_vals = dates.dt.month().is_in([3, 6, 9, 12]) & (
+                            dates == dates.dt.month_end()
+                        )
+                    elif polars_feature == "is_year_start":
+                        feat_vals = (dates.dt.month() == 1) & (dates.dt.day() == 1)
+                    elif polars_feature == "is_year_end":
+                        feat_vals = (dates.dt.month() == 12) & (
+                            dates == dates.dt.month_end()
+                        )
+                    else:
+                        feat_vals = getattr(dates.dt, polars_feature)()
+                elif pl is not None and isinstance(dates, pl_Series):
+                    polars_feature = {
+                        "dayofyear": "ordinal_day",
+                        "day_of_year": "ordinal_day",
+                        "weekofyear": "week",
+                        "dayofweek": "weekday",
+                        "day_of_week": "weekday",
+                    }.get(feature, feature)
+                    if polars_feature == "daysinmonth":
+                        feat_vals = dates.dt.month_end().dt.day()
+                    elif polars_feature == "is_month_start":
+                        feat_vals = dates == dates.dt.month_start()
+                    elif polars_feature == "is_month_end":
+                        feat_vals = dates == dates.dt.month_end()
+                    elif polars_feature == "is_quarter_start":
+                        feat_vals = dates.dt.month().is_in([1, 4, 7, 10]) & (
+                            dates.dt.day() == 1
+                        )
+                    elif polars_feature == "is_quarter_end":
+                        feat_vals = dates.dt.month().is_in([3, 6, 9, 12]) & (
+                            dates == dates.dt.month_end()
+                        )
+                    elif polars_feature == "is_year_start":
+                        feat_vals = (dates.dt.month() == 1) & (dates.dt.day() == 1)
+                    elif polars_feature == "is_year_end":
+                        feat_vals = (dates.dt.month() == 12) & (
+                            dates == dates.dt.month_end()
+                        )
+                    else:
+                        accessor = getattr(dates.dt, polars_feature)
+                        feat_vals = accessor() if callable(accessor) else accessor
+                else:
+                    raise AttributeError
+            except AttributeError:
+                raise ValueError(
+                    f"Unknown date feature '{feature}'. "
+                    f"Supported features: {supported}. "
+                    "You can also pass a callable."
+                ) from None
         if isinstance(feat_vals, (pd.Index, pd.Series)):
             feat_vals = np.asarray(feat_vals)
             feat_dtype = date_features_dtypes.get(feature)

--- a/mlforecast/core.py
+++ b/mlforecast/core.py
@@ -569,8 +569,9 @@ class TimeSeries:
                         "dayofyear": "ordinal_day",
                         "day_of_year": "ordinal_day",
                         "weekofyear": "week",
-                        "dayofweek": "weekday",
-                        "day_of_week": "weekday",
+                        "weekday": "weekday_zero_based",
+                        "dayofweek": "weekday_zero_based",
+                        "day_of_week": "weekday_zero_based",
                     }.get(feature, feature)
                     if polars_feature == "daysinmonth":
                         feat_vals = dates.dt.month_end().dt.day()
@@ -592,6 +593,9 @@ class TimeSeries:
                         feat_vals = (dates.dt.month() == 12) & (
                             dates == dates.dt.month_end()
                         )
+                    elif polars_feature == "weekday_zero_based":
+                        # Polars weekday is ISO-based (Mon=1..Sun=7). Match pandas semantics.
+                        feat_vals = dates.dt.weekday() - 1
                     else:
                         feat_vals = getattr(dates.dt, polars_feature)()
                 elif pl is not None and isinstance(dates, pl_Series):
@@ -599,8 +603,9 @@ class TimeSeries:
                         "dayofyear": "ordinal_day",
                         "day_of_year": "ordinal_day",
                         "weekofyear": "week",
-                        "dayofweek": "weekday",
-                        "day_of_week": "weekday",
+                        "weekday": "weekday_zero_based",
+                        "dayofweek": "weekday_zero_based",
+                        "day_of_week": "weekday_zero_based",
                     }.get(feature, feature)
                     if polars_feature == "daysinmonth":
                         feat_vals = dates.dt.month_end().dt.day()
@@ -622,6 +627,9 @@ class TimeSeries:
                         feat_vals = (dates.dt.month() == 12) & (
                             dates == dates.dt.month_end()
                         )
+                    elif polars_feature == "weekday_zero_based":
+                        # Polars weekday is ISO-based (Mon=1..Sun=7). Match pandas semantics.
+                        feat_vals = dates.dt.weekday() - 1
                     else:
                         accessor = getattr(dates.dt, polars_feature)
                         feat_vals = accessor() if callable(accessor) else accessor

--- a/mlforecast/forecast.py
+++ b/mlforecast/forecast.py
@@ -151,7 +151,15 @@ class MLForecast:
             freq (str or int or pd.offsets.BaseOffset): Pandas offset, pandas offset alias, e.g. 'D', 'W-THU' or integer denoting the frequency of the series.
             lags (list of int, optional): Lags of the target to use as features. Defaults to None.
             lag_transforms (dict of int to list of functions, optional): Mapping of target lags to their transformations. Defaults to None.
-            date_features (list of str or callable, optional): Features computed from the dates. Can be pandas date attributes or functions that will take the dates as input. Defaults to None.
+            date_features (list of str or callable, optional): Features computed from the dates.
+                Can be pandas/polars date attributes or callables that take the dates as input.
+                Built-in string options are:
+                ['year', 'month', 'day', 'hour', 'minute', 'second', 'dayofyear',
+                 'day_of_year', 'weekofyear', 'week', 'dayofweek', 'day_of_week',
+                 'weekday', 'quarter', 'daysinmonth', 'is_month_start', 'is_month_end',
+                 'is_quarter_start', 'is_quarter_end', 'is_year_start', 'is_year_end'].
+                For broad compatibility across pandas versions/backends prefer `week` over
+                `weekofyear` and `dayofyear` over `day_of_year`. Defaults to None.
             num_threads (int): Number of threads to use when computing the features. Use -1 to use all available CPU cores. Defaults to 1.
             target_transforms (list of transformers, optional): Transformations that will be applied to the target before computing the features and restored after the forecasting step. Defaults to None.
             lag_transforms_namer (callable, optional): Function that takes a transformation (either function or class), a lag and extra arguments and produces a name. Defaults to None.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2000,3 +2000,14 @@ def test_date_feature_aliases_supported(engine, freq, feature):
         series, id_col="unique_id", time_col="ds", target_col="y"
     )
     assert feature in transformed.columns
+
+
+@pytest.mark.parametrize("feature", ["weekday", "dayofweek", "day_of_week"])
+def test_polars_dayofweek_aliases_match_pandas_semantics(feature):
+    series = generate_daily_series(2, min_length=20, max_length=20, engine="polars")
+    ts = TimeSeries(freq="1d", lags=[1], date_features=[feature])
+    transformed = ts.fit_transform(
+        series, id_col="unique_id", time_col="ds", target_col="y"
+    )
+    expected = transformed["ds"].to_pandas().dt.dayofweek.to_numpy()
+    np.testing.assert_array_equal(transformed[feature].to_numpy(), expected)


### PR DESCRIPTION
## Summary
- Document supported built-in string `date_features` in `docs/core.html.md`.
- Expand `MLForecast` constructor docstring with explicit supported options and compatibility guidance.
- Improve date-feature resolution across pandas/polars aliases (e.g. `day_of_year`, `day_of_week`, `weekofyear`) and calendar-boundary features.
- Raise clear `ValueError` listing supported features when an unknown string is used.
- Add tests for invalid feature errors and backend alias support.

## Why
Makes supported features explicit and reduces backend/version-specific surprises for date feature extraction.

## Tests
- `/home/welink/dev/work/Nixtla/mlforecast/.venv/bin/pytest --no-cov tests/test_core.py -k "invalid_date_feature or date_feature_aliases_supported" -vv`

Closes #315