### PR TITLE
[FIX] Skips build-docs for dependabot PRs

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -19,6 +19,7 @@ on:
 
 jobs:
   build-docs:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Clone repo


### PR DESCRIPTION
The PR's from dependabot fail due to not having access token for building the docs. This PR skips build-docs workflow for dependabot