### PR TITLE
fix(optimization): return inf when sampler picks no-feature config

### DIFF
--- a/mlforecast/optimization.py
+++ b/mlforecast/optimization.py
@@ -108,6 +108,12 @@ def mlforecast_objective(
     """
     def objective(trial: optuna.Trial) -> float:
         config = copy.deepcopy(config_fn(trial))
+        if all(
+            config["mlf_init_params"].get(k) is None
+            for k in ("lags", "lag_transforms", "date_features")
+        ):
+            trial.set_user_attr("config", copy.deepcopy(config))
+            return float("inf")
         model_copy = clone(model)
         model_params = config["model_params"]
         static_features = config["mlf_fit_params"].get("static_features", [])


### PR DESCRIPTION
Closes #637.

`mlforecast_objective`'s `objective` runs `config_fn(trial)` and hands the resulting MLForecast config straight to the model fit even when the sampled hyperparameters specify no input features (`lags`, `lag_transforms`, and `date_features` all `None`). That produces a zero-column feature matrix and sklearn raises:

```
ValueError: at least one array or dtype is required
```

The v1.0.2 objective guarded against this case ([optimization.py:78-83](https://github.com/Nixtla/mlforecast/blob/v1.0.2/mlforecast/optimization.py#L78-L83)) and returned `np.inf` so Optuna treated the trial as worst-case and moved on. The guard was dropped in 1.0.3 (commit 7526c5649a) without a follow-up. This restores it.

### Patch

Matches the snippet the reporter validated locally, plus a `trial.set_user_attr("config", ...)` so the skipped configs still show up in `study.trials_dataframe()` for diagnostics, keeps the existing diagnostics behavior consistent with successful trials.