### PR TITLE
[CHORE] distributed guard against pooled lag transforms in DistributedMLForecast

### DIFF
--- a/mlforecast/distributed/forecast.py
+++ b/mlforecast/distributed/forecast.py
@@ -125,6 +125,25 @@ class DistributedMLForecast:
             lag_transforms_namer=lag_transforms_namer,
             date_features_as_dummies=date_features_as_dummies,
         )
+        pooled_tfms = self._base_ts._get_pooled_tfms()
+        if pooled_tfms:
+            pooled_names = sorted(
+                name for tfms in pooled_tfms.values() for name in tfms
+            )
+            raise NotImplementedError(
+                "Pooled lag transforms (those configured with `global_`, "
+                "`groupby` or `partition_by`) are not supported by "
+                "DistributedMLForecast. The distributed engines shard the data "
+                "by the id column and compute features independently on each "
+                "partition, so a transform that aggregates across series (the "
+                "whole dataset for `global_`, a group for `groupby`) would only "
+                "see the series in its own partition and silently produce "
+                "incorrect results. Partition-based transforms rely on the same "
+                "cross-series parent-calendar machinery, which assumes a single "
+                f"TimeSeries owns every series. Offending feature(s): "
+                f"{pooled_names}. Use the local (non-distributed) MLForecast for "
+                "these transforms."
+            )
         self.engine = engine
         self.num_partitions = num_partitions
 
@@ -466,9 +485,7 @@ class DistributedMLForecast:
         )
 
     @staticmethod
-    def _attach_x_df(
-        part: pd.DataFrame, uid_to_xdf: dict
-    ) -> Iterable[pd.DataFrame]:
+    def _attach_x_df(part: pd.DataFrame, uid_to_xdf: dict) -> Iterable[pd.DataFrame]:
         """Attach each partition's packed X_df blob to its rows, matched on first_uid.
 
         Used in place of ``fa.join`` for Step 4 of ``_build_x_df_per_partition``:
@@ -482,7 +499,9 @@ class DistributedMLForecast:
         yield part
 
     @staticmethod
-    def _pack_x_df(part: pd.DataFrame, partition_key_col: str) -> Iterable[pd.DataFrame]:
+    def _pack_x_df(
+        part: pd.DataFrame, partition_key_col: str
+    ) -> Iterable[pd.DataFrame]:
         """Serialize one partition's X_df rows as a base64 string, keyed by first_uid.
 
         Base64 encoding avoids binary-column type issues when the packed blob flows
@@ -582,13 +601,15 @@ class DistributedMLForecast:
         id_col = self._base_ts.id_col
 
         # Step 1 — build uid → first_uid mapping on the driver (all_uids column only, small).
-        ts_df = fa.as_pandas(fa.select_columns(partition_results, ["all_uids", "first_uid"]))
+        ts_df = fa.as_pandas(
+            fa.select_columns(partition_results, ["all_uids", "first_uid"])
+        )
         uid_map_df = (
-            ts_df
-            .assign(all_uids=ts_df["all_uids"].apply(cloudpickle.loads))
+            ts_df.assign(all_uids=ts_df["all_uids"].apply(cloudpickle.loads))
             .explode("all_uids")
-            .rename(columns={"all_uids": id_col, "first_uid": "__partition_key__"})
-            [[id_col, "__partition_key__"]]
+            .rename(columns={"all_uids": id_col, "first_uid": "__partition_key__"})[
+                [id_col, "__partition_key__"]
+            ]
             .reset_index(drop=True)
         )
 
@@ -889,7 +910,13 @@ class DistributedMLForecast:
             partition_mask = ufp.is_in(new_df[ts.id_col], ts.uids)
             partition_df = ufp.filter_with_mask(new_df, partition_mask)
             ts.update(partition_df)
-            yield [cloudpickle.dumps(ts), data["train"], data["valid"], str(ts.uids[0]), cloudpickle.dumps(list(ts.uids))]
+            yield [
+                cloudpickle.dumps(ts),
+                data["train"],
+                data["valid"],
+                str(ts.uids[0]),
+                cloudpickle.dumps(list(ts.uids)),
+            ]
 
     def update(self, df: pd.DataFrame) -> None:
         """Update the values of the stored series.

--- a/tests/test_distributed_forecast.py
+++ b/tests/test_distributed_forecast.py
@@ -13,7 +13,9 @@ from mlforecast.lag_transforms import ExpandingMean, RollingMean
 from mlforecast.utils import generate_daily_series
 
 if sys.platform != "linux":
-    pytest.skip("Distributed interface is only supported on Linux", allow_module_level=True)
+    pytest.skip(
+        "Distributed interface is only supported on Linux", allow_module_level=True
+    )
 
 warnings.simplefilter("ignore", FutureWarning)
 
@@ -71,6 +73,7 @@ class _RecordingDaskRegressor(BaseEstimator):
             )
         self.model_ = _RecordingLocalModel(weights)
         return self
+
 
 def test_dask_distributed_forecast(partitioned_series):
     # test existing features provide the same result
@@ -144,7 +147,10 @@ def test_dask_distributed_forecast_with_x_df():
 
     # build future exog: one row per (unique_id, future date)
     last_dates = (
-        series.groupby("unique_id")["ds"].max().reset_index().rename(columns={"ds": "last_ds"})
+        series.groupby("unique_id")["ds"]
+        .max()
+        .reset_index()
+        .rename(columns={"ds": "last_ds"})
     )
     future_rows = []
     for _, row in last_dates.iterrows():
@@ -189,3 +195,36 @@ def test_dask_distributed_forecast_with_new_df():
 
     assert preds.shape[0] == 5 * 5
     assert set(preds["unique_id"]) == set(series["unique_id"])
+
+
+@pytest.mark.parametrize(
+    "pooled_kwargs",
+    [
+        {"global_": True},
+        {"groupby": ["brand"]},
+        {"partition_by": ["promo"]},
+    ],
+)
+def test_distributed_rejects_pooled_transforms(pooled_kwargs):
+    """Pooled transforms can't be sharded by id, so init must fail loudly.
+
+    The distributed engines compute features independently per partition, so a
+    transform that aggregates across series would only see its own slice. The
+    guard fires at construction (no engine needed).
+    """
+    with pytest.raises(NotImplementedError, match="Pooled lag transforms"):
+        DistributedMLForecast(
+            models=[DaskLGBMForecast(verbosity=-1, random_state=0)],
+            freq="D",
+            lag_transforms={1: [RollingMean(window_size=7, **pooled_kwargs)]},
+        )
+
+
+def test_distributed_allows_local_transforms():
+    """A plain (per-series) lag transform must still construct fine."""
+    DistributedMLForecast(
+        models=[DaskLGBMForecast(verbosity=-1, random_state=0)],
+        freq="D",
+        lags=[1, 2],
+        lag_transforms={1: [RollingMean(window_size=7)]},
+    )

--- a/tests/test_distributed_forecast.py
+++ b/tests/test_distributed_forecast.py
@@ -7,15 +7,15 @@ import pandas as pd
 import pytest
 from sklearn.base import BaseEstimator
 
-from mlforecast.distributed import DistributedMLForecast
-from mlforecast.distributed.models.dask.lgb import DaskLGBMForecast
-from mlforecast.lag_transforms import ExpandingMean, RollingMean
-from mlforecast.utils import generate_daily_series
-
 if sys.platform != "linux":
     pytest.skip(
         "Distributed interface is only supported on Linux", allow_module_level=True
     )
+
+from mlforecast.distributed import DistributedMLForecast
+from mlforecast.distributed.models.dask.lgb import DaskLGBMForecast
+from mlforecast.lag_transforms import ExpandingMean, RollingMean
+from mlforecast.utils import generate_daily_series
 
 warnings.simplefilter("ignore", FutureWarning)
 

--- a/tests/test_distributed_forecast.py
+++ b/tests/test_distributed_forecast.py
@@ -1,7 +1,6 @@
 import sys
 import warnings
 
-import dask.dataframe as dd
 import numpy as np
 import pandas as pd
 import pytest
@@ -11,6 +10,8 @@ if sys.platform != "linux":
     pytest.skip(
         "Distributed interface is only supported on Linux", allow_module_level=True
     )
+
+import dask.dataframe as dd
 
 from mlforecast.distributed import DistributedMLForecast
 from mlforecast.distributed.models.dask.lgb import DaskLGBMForecast


### PR DESCRIPTION
## Summary

Raise a clear `NotImplementedError` when a pooled lag transform (`global_`, `groupby`, or `partition_by`) is configured on `DistributedMLForecast`, instead of silently returning incorrect results.

## Problem

`DistributedMLForecast` shards data **by the id column** and runs a fully independent, deep-copied `TimeSeries.fit_transform`/`predict` on each partition:

- `_preprocess_partitions` sets `partition = dict(by=id_col)` for every backend (Spark/Dask/Ray).
- `_preprocess_partition` does `copy.deepcopy(base_ts)` then `ts.fit_transform(part, ...)`, and `_predict` calls `ts.predict(...)` per partition.

Plain/local lag transforms survive this because they're computed per series, and a series' rows always stay within one partition. **Pooled transforms don't**: their aggregates are defined over a population the sharding splits across workers —

- `global_` aggregates over the *whole dataset*,
- `groupby=[...]` aggregates over a *whole group* (whose series the id-sharding scatters),
- `partition_by` rides the same cross-series parent-calendar machinery, which assumes one `TimeSeries` owns every series.

Each worker only ever sees its own slice, so the feature is computed over the wrong set of series. Crucially, there was **no guard** — this ran to completion and returned plausible-looking but wrong numbers.

## Change

In `DistributedMLForecast.__init__`, right after `_base_ts` is built, detect pooled transforms via `TimeSeries._get_pooled_tfms()` and raise `NotImplementedError` if any are present. The guard:

- fires **at construction**, before any engine is touched, so it fails immediately regardless of backend and needs no cluster;
- names the offending feature(s) in the message and points users to the local (non-distributed) `MLForecast`.

## Tests

- `test_distributed_rejects_pooled_transforms` — parametrized over `global_`, `groupby`, and `partition_by`; asserts each raises `NotImplementedError`.
- `test_distributed_allows_local_transforms` — guards against over-rejection: a plain per-series `RollingMean` must still construct fine.

## Notes

The guard rejects **all** pooled modes, including local-only `partition_by` (which is mathematically per-series). I chose the conservative boundary — `_get_pooled_tfms()` is the codebase's definition of "pooled," and that mode still relies on the parent-calendar + predict-time machinery that has never been validated under per-partition execution. Allowing it later is a one-line change once there's a distributed test backing it.
