### PR TITLE
[CHORE] Narwhals Refactor

### DIFF
--- a/mlforecast/core.py
+++ b/mlforecast/core.py
@@ -235,6 +235,19 @@ def _static_feature_changes_over_time(start_series, end_series) -> bool:
     return bool(changed.fill_null(False).any())
 
 
+def _to_native_uids(values, *, df):
+    """Wrap ids/dates into the backend-native container mlforecast exposes as
+    ``TimeSeries.uids`` / ``TimeSeries.last_dates``.
+
+    pandas -> ``pd.Index``, polars -> ``pl.Series``. Centralized here because these
+    attributes are observable API (tests rely on ``.tolist()`` and fancy indexing),
+    so their native type must be produced in exactly one place.
+    """
+    if isinstance(df, pd.DataFrame):
+        return pd.Index(values)
+    return pl_Series(values)
+
+
 class TimeSeries:
     """Utility class for storing and transforming time series data."""
 
@@ -520,12 +533,8 @@ class TimeSeries:
         if data.ndim == 2:
             data = data[:, 0]
         ga = GroupedArray(data, indptr)
-        if isinstance(df, pd.DataFrame):
-            self.uids = pd.Index(uids)
-            self.last_dates = pd.Index(times)
-        else:
-            self.uids = uids
-            self.last_dates = pl_Series(times)
+        self.uids = _to_native_uids(uids, df=df)
+        self.last_dates = _to_native_uids(times, df=df)
         self._check_aligned_ends()
         if self._sort_idxs is not None:
             self._restore_idxs: Optional[np.ndarray] = np.empty(
@@ -1787,6 +1796,7 @@ class TimeSeries:
         """
         validate_format(df, self.id_col, self.time_col, self.target_col)
         uids = self.uids
+        # pd.Index is not a narwhals-native input; normalize to Series for ufp.match_if_categorical
         if isinstance(uids, pd.Index):
             uids = pd.Series(uids)
         uids, new_ids = ufp.match_if_categorical(uids, df[self.id_col])
@@ -1831,9 +1841,8 @@ class TimeSeries:
         last_dates = ufp.sort(last_dates, by=self.id_col)
         self.last_dates = ufp.cast(last_dates[self.time_col], self.last_dates.dtype)
         self.uids = ufp.sort(sizes[self.id_col])
-        if isinstance(df, pd.DataFrame):
-            self.uids = pd.Index(self.uids)
-            self.last_dates = pd.Index(self.last_dates)
+        self.uids = _to_native_uids(self.uids, df=df)
+        self.last_dates = _to_native_uids(self.last_dates, df=df)
         if new_groups.any():
             if self.target_transforms is not None:
                 raise ValueError("Can not update target_transforms with new series.")

--- a/mlforecast/core.py
+++ b/mlforecast/core.py
@@ -254,7 +254,10 @@ class TimeSeries:
 
     # Per-predict state (set in ``_predict_setup``, used in the horizon loop).
     # Declared here so mypy has a type regardless of method processing order.
-    _uniform_dates: bool
+    # _uniform_dates defaults to False so the date-feature broadcast fast
+    # path stays off if the feature computation runs without a prior
+    # ``_predict_setup`` (the non-broadcast path is always correct).
+    _uniform_dates: bool = False
     _feature_null_cols: List[str]
     _xdf_null_cols: Optional[List[str]]
 
@@ -1224,7 +1227,12 @@ class TimeSeries:
             state.append_predictions(self.curr_dates, new_arr, len(new_arr))
 
     def _update_features(self) -> DataFrame:
-        """Compute the current values of all the features using the latest values of the time series."""
+        """Compute the current values of all the features using the latest values of the time series.
+
+        Expects the per-predict state from ``_predict_setup`` (``curr_dates``,
+        ``static_features_``, pooled states); ``_uniform_dates`` safely
+        defaults to False if setup hasn't run.
+        """
         features_df = self._compute_features_df()
         return ufp.horizontal_concat([self.static_features_, features_df])
 

--- a/mlforecast/core.py
+++ b/mlforecast/core.py
@@ -45,6 +45,7 @@ from mlforecast.target_transforms import (
 )
 
 from .compat import CatBoostRegressor
+from .data_validation import _index_to_series
 from .grouped_array import GroupedArray
 from .lag_transforms import Lag, _BaseLagTransform
 from .pooled import (
@@ -235,8 +236,7 @@ def _static_feature_changes_over_time(start_series, end_series) -> bool:
     return bool(changed.fill_null(False).any())
 
 
-# native-container boundary for observable uids/last_dates (pd.Index/pl.Series); tests rely on these types
-def _to_native_uids(values, *, df):
+def _to_native_index(values, *, df):
     """Wrap ids/dates into the backend-native container mlforecast exposes as
     ``TimeSeries.uids`` / ``TimeSeries.last_dates``.
 
@@ -410,12 +410,7 @@ class TimeSeries:
         """Check that all series end at the same timestamp when using pooled lag transforms."""
         if not self._get_pooled_tfms():
             return
-        # pd.Index is not a narwhals input type; wrap to Series before from_native
-        last_dates = (
-            pd.Series(self.last_dates)
-            if isinstance(self.last_dates, pd.Index)
-            else self.last_dates
-        )
+        last_dates = _index_to_series(self.last_dates)
         aligned = nw.from_native(last_dates, series_only=True).n_unique() == 1
         if not aligned:
             raise ValueError(
@@ -541,8 +536,8 @@ class TimeSeries:
         if data.ndim == 2:
             data = data[:, 0]
         ga = GroupedArray(data, indptr)
-        self.uids = _to_native_uids(uids, df=df)
-        self.last_dates = _to_native_uids(times, df=df)
+        self.uids = _to_native_index(uids, df=df)
+        self.last_dates = _to_native_index(times, df=df)
         self._check_aligned_ends()
         if self._sort_idxs is not None:
             self._restore_idxs: Optional[np.ndarray] = np.empty(
@@ -765,9 +760,7 @@ class TimeSeries:
         backend = nw.get_native_namespace(nw_bucket)
         join_df = nw_bucket.select(join_cols)
         for name, vals in bucket_vals.items():
-            join_df = join_df.with_columns(
-                nw.new_series(name, vals, backend=backend).alias(name)
-            )
+            join_df = join_df.with_columns(nw.new_series(name, vals, backend=backend))
         join_df = join_df.to_native()
         left = nw.from_native(df, eager_only=True).select(join_cols).to_native()
         joined = nw.to_native(
@@ -793,7 +786,6 @@ class TimeSeries:
             # callable-returned native types have no narwhals equivalent
             if isinstance(feat_vals, pd.DataFrame):
                 return {col: np.asarray(feat_vals[col]) for col in feat_vals.columns}
-            # callable-returned native types have no narwhals equivalent
             if isinstance(feat_vals, (pd.Index, pd.Series)):
                 feat_vals = np.asarray(feat_vals)
             return {feat_name: feat_vals}
@@ -805,7 +797,6 @@ class TimeSeries:
             if feature in ("week", "weekofyear"):
                 dates = dates.isocalendar()
             feat_vals = getattr(dates, feature)
-            # DatetimeIndex date-attribute access has no narwhals equivalent
             if isinstance(feat_vals, (pd.Index, pd.Series)):
                 feat_vals = np.asarray(feat_vals)
                 feat_dtype = date_features_dtypes.get(feature)
@@ -1525,11 +1516,7 @@ class TimeSeries:
         self._xdf_null_cols = None
         # when all series end at the same timestamp, per-step date features
         # are constant across series and can be computed on a single date
-        last_dates = (
-            pd.Series(self.last_dates)
-            if isinstance(self.last_dates, pd.Index)
-            else self.last_dates
-        )
+        last_dates = _index_to_series(self.last_dates)
         self._uniform_dates = bool(
             nw.from_native(last_dates, series_only=True).n_unique() == 1
         )
@@ -1938,10 +1925,7 @@ class TimeSeries:
             validate_new_data: If True, validate continuity, start dates, and frequency.
         """
         validate_format(df, self.id_col, self.time_col, self.target_col)
-        uids = self.uids
-        # pd.Index is not a narwhals-native input; normalize to Series for ufp.match_if_categorical
-        if isinstance(uids, pd.Index):
-            uids = pd.Series(uids)
+        uids = _index_to_series(self.uids)
         uids, new_ids = ufp.match_if_categorical(uids, df[self.id_col])
         df = ufp.copy_if_pandas(df, deep=False)
         df = ufp.assign_columns(df, self.id_col, new_ids)
@@ -1950,15 +1934,15 @@ class TimeSeries:
         values = values.astype(self.ga.data.dtype, copy=False)
         self._check_aligned_ends()
         if self._pooled_states:
-            # pd.Index guard before from_native
-            uids_nw = pd.Series(uids) if isinstance(uids, pd.Index) else uids
-            new_ids_nw = (
-                pd.Series(new_ids) if isinstance(new_ids, pd.Index) else new_ids
+            uids_nw = nw.from_native(_index_to_series(uids), series_only=True).alias(
+                "_uid"
             )
-            expected_count = len(
-                set(nw.from_native(uids_nw, series_only=True).to_list())
-                | set(nw.from_native(new_ids_nw, series_only=True).to_list())
-            )
+            new_ids_nw = nw.from_native(
+                _index_to_series(new_ids), series_only=True
+            ).alias("_uid")
+            expected_count = nw.concat(
+                [uids_nw.to_frame(), new_ids_nw.to_frame()], how="vertical"
+            )["_uid"].n_unique()
             counts = (
                 nw.from_native(df, eager_only=True)
                 .group_by(self.time_col)
@@ -1987,8 +1971,8 @@ class TimeSeries:
         last_dates = ufp.sort(last_dates, by=self.id_col)
         self.last_dates = ufp.cast(last_dates[self.time_col], self.last_dates.dtype)
         self.uids = ufp.sort(sizes[self.id_col])
-        self.uids = _to_native_uids(self.uids, df=df)
-        self.last_dates = _to_native_uids(self.last_dates, df=df)
+        self.uids = _to_native_index(self.uids, df=df)
+        self.last_dates = _to_native_index(self.last_dates, df=df)
         if new_groups.any():
             if self.target_transforms is not None:
                 raise ValueError("Can not update target_transforms with new series.")

--- a/mlforecast/core.py
+++ b/mlforecast/core.py
@@ -252,6 +252,12 @@ def _to_native_uids(values, *, df):
 class TimeSeries:
     """Utility class for storing and transforming time series data."""
 
+    # Per-predict state (set in ``_predict_setup``, used in the horizon loop).
+    # Declared here so mypy has a type regardless of method processing order.
+    _uniform_dates: bool
+    _feature_null_cols: List[str]
+    _xdf_null_cols: Optional[List[str]]
+
     def __init__(
         self,
         freq: Freq,
@@ -1228,6 +1234,11 @@ class TimeSeries:
 
     def _update_features(self) -> DataFrame:
         """Compute the current values of all the features using the latest values of the time series."""
+        features_df = self._compute_features_df()
+        return ufp.horizontal_concat([self.static_features_, features_df])
+
+    def _compute_features_df(self) -> DataFrame:
+        """Advance ``curr_dates`` one step and compute the features frame (without statics)."""
         self.curr_dates: Union[pd.Index, pl_Series] = ufp.offset_times(
             self.curr_dates, self.freq, 1
         )
@@ -1286,11 +1297,23 @@ class TimeSeries:
                             lookup[bid] = val
                         features[name] = lookup[state.series_bucket_id]
 
+        if self._uniform_dates and self.date_features:
+            # all series are on the same timestamp, so date features are
+            # constant across series: compute them on a single date and
+            # broadcast instead of recomputing on n_series identical dates.
+            # restricted to non-callables, which are guaranteed elementwise
+            broadcast_idx = np.zeros(len(self.uids), dtype=np.int64)
         for feature in self.date_features:
-            for feat_name, feat_vals in self._compute_date_feature(
-                self.curr_dates, feature
-            ).items():
-                features[feat_name] = feat_vals
+            if self._uniform_dates and not callable(feature):
+                for feat_name, feat_vals in self._compute_date_feature(
+                    self.curr_dates[:1], feature
+                ).items():
+                    features[feat_name] = feat_vals[broadcast_idx]
+            else:
+                for feat_name, feat_vals in self._compute_date_feature(
+                    self.curr_dates, feature
+                ).items():
+                    features[feat_name] = feat_vals
 
         # Category C: native-container boundary — uids/df constructor selected per backend
         if isinstance(self.last_dates, pl_Series):
@@ -1300,8 +1323,10 @@ class TimeSeries:
         self._feature_null_cols = self._null_cols_in_feature_values(
             features, nan_is_null=df_constructor is pd.DataFrame
         )
-        features_df = df_constructor(features)[self.features]
-        return ufp.horizontal_concat([self.static_features_, features_df])
+        features_df = df_constructor(features)
+        if list(features_df.columns) != self.features:
+            features_df = features_df[self.features]
+        return features_df
 
     def _null_cols_in_feature_values(
         self, features: Dict[str, Any], nan_is_null: bool
@@ -1425,7 +1450,11 @@ class TimeSeries:
         X_row = None
         if X_df is not None:
             X_row = self._update_partition_assignments(X_df)
-        new_x = self._update_features()
+        # same frame _update_features builds, but with the statics trimmed to
+        # model features (_statics_keep) so columns dropped by the
+        # features_order_ selection below aren't carried through every step
+        features_df = self._compute_features_df()
+        new_x = ufp.horizontal_concat([self._statics_keep, features_df])
         # statics were scanned in _predict_setup and computed features while
         # building them in _update_features; assembled here in new_x column
         # order (statics, features, X_row) so the warning matches a full scan
@@ -1456,7 +1485,8 @@ class TimeSeries:
         if cols_with_nulls:
             warnings.warn(f"Found null values in {', '.join(cols_with_nulls)}.")
         self._h += 1
-        new_x = new_x[self.features_order_]
+        if list(new_x.columns) != self.features_order_:
+            new_x = new_x[self.features_order_]
         if self.as_numpy:
             new_x = ufp.to_numpy(new_x)
         return new_x
@@ -1491,8 +1521,24 @@ class TimeSeries:
         # Null-diagnostic state for _get_features_for_next_step. Statics are
         # fixed for the whole predict, so scan them once here (boundary)
         # instead of once per horizon step (hot loop).
-        self._feature_null_cols: List[str] = []
-        self._xdf_null_cols: Optional[List[str]] = None
+        self._feature_null_cols = []
+        self._xdf_null_cols = None
+        # when all series end at the same timestamp, per-step date features
+        # are constant across series and can be computed on a single date
+        last_dates = (
+            pd.Series(self.last_dates)
+            if isinstance(self.last_dates, pd.Index)
+            else self.last_dates
+        )
+        self._uniform_dates = bool(
+            nw.from_native(last_dates, series_only=True).n_unique() == 1
+        )
+        # _predict_setup runs once per model; the statics-derived state below
+        # is fixed for the whole predict, so reuse it across models
+        # (TimeSeries.predict clears _static_null_src per call)
+        if getattr(self, "_static_null_src", None) is self.static_features_:
+            return
+        self._static_null_src = self.static_features_
         self._static_null_cols: List[str] = []
         statics_nw = nw.from_native(self.static_features_, eager_only=True)
         if statics_nw.columns:
@@ -1500,6 +1546,18 @@ class TimeSeries:
             self._static_null_cols = [
                 c for c, n in zip(statics_nw.columns, static_null_counts) if n
             ]
+        # cache the statics restricted to actual model features (usually all
+        # but the id column, which can itself be a feature when the user lists
+        # it in static_features) so the per-step feature assembly doesn't
+        # carry columns that the features_order_ selection drops at the end.
+        # when no static column is a feature keep the full frame: it provides
+        # the row count of new_x (e.g. no computed features at all)
+        feature_set = set(self.features_order_)
+        static_cols = [c for c in statics_nw.columns if c in feature_set]
+        if static_cols and static_cols != statics_nw.columns:
+            self._statics_keep = self.static_features_[static_cols]
+        else:
+            self._statics_keep = self.static_features_
 
     def _predict_recursive(
         self,
@@ -1752,6 +1810,8 @@ class TimeSeries:
                     f"{sorted(required_future_cols)}."
                 )
         with self._maybe_subset(idxs):
+            # invalidate the per-predict statics cache in _predict_setup
+            self._static_null_src = None
             if X_df is not None:
                 if self.id_col not in X_df or self.time_col not in X_df:
                     raise ValueError(

--- a/mlforecast/core.py
+++ b/mlforecast/core.py
@@ -235,6 +235,7 @@ def _static_feature_changes_over_time(start_series, end_series) -> bool:
     return bool(changed.fill_null(False).any())
 
 
+# Category C: native-container boundary for observable uids/last_dates (pd.Index/pl.Series); tests rely on these types
 def _to_native_uids(values, *, df):
     """Wrap ids/dates into the backend-native container mlforecast exposes as
     ``TimeSeries.uids`` / ``TimeSeries.last_dates``.
@@ -403,6 +404,7 @@ class TimeSeries:
         """Check that all series end at the same timestamp when using pooled lag transforms."""
         if not self._get_pooled_tfms():
             return
+        # Category C: pd.Index is not a narwhals input type; wrap to Series before from_native
         last_dates = (
             pd.Series(self.last_dates)
             if isinstance(self.last_dates, pd.Index)
@@ -782,18 +784,22 @@ class TimeSeries:
         if callable(feature):
             feat_name = feature.__name__
             feat_vals = feature(dates)
+            # Category C: callable-returned native types have no narwhals equivalent
             if isinstance(feat_vals, pd.DataFrame):
                 return {col: np.asarray(feat_vals[col]) for col in feat_vals.columns}
+            # Category C: callable-returned native types have no narwhals equivalent
             if isinstance(feat_vals, (pd.Index, pd.Series)):
                 feat_vals = np.asarray(feat_vals)
             return {feat_name: feat_vals}
 
         # regular string feature
         feat_name = feature
+        # Category C: DatetimeIndex date-attribute access has no narwhals equivalent
         if isinstance(dates, pd.DatetimeIndex):
             if feature in ("week", "weekofyear"):
                 dates = dates.isocalendar()
             feat_vals = getattr(dates, feature)
+            # Category C: DatetimeIndex date-attribute access has no narwhals equivalent
             if isinstance(feat_vals, (pd.Index, pd.Series)):
                 feat_vals = np.asarray(feat_vals)
                 feat_dtype = date_features_dtypes.get(feature)
@@ -975,6 +981,7 @@ class TimeSeries:
         ]
         if date_features:
             unique_dates = df[self.time_col].unique()
+            # Category C: pandas positional-map fast path; narwhals rewrite would regress this hot path
             if isinstance(df, pd.DataFrame):
                 # all kinds of trickery to make this fast
                 unique_dates = pd.Index(unique_dates)
@@ -1435,6 +1442,7 @@ class TimeSeries:
                     if before_predict_callback is not None:
                         new_x = before_predict_callback(new_x)
                     model_x = new_x
+                    # Category C: sklearn models consume pandas/numpy; native conversion at the model boundary
                     if isinstance(model, CatBoostRegressor) and isinstance(
                         new_x, pl_DataFrame
                     ):
@@ -1503,6 +1511,7 @@ class TimeSeries:
                     ufp.offset_times(self.curr_dates, self.freq, h + 1)
                     for h in horizons_to_predict
                 ]
+                # Category C: backend-specific date-matrix build at prediction assembly
                 # Stack: each row is a series, each col is a horizon
                 dates_matrix = pl.DataFrame(dates_per_horizon).transpose()
                 # Flatten row by row: [s0_h0, s0_h1, ..., s1_h0, s1_h1, ...]
@@ -1572,6 +1581,7 @@ class TimeSeries:
                             )
                             model_x = new_x[h_cols]
                     horizon_model = model[h]
+                    # Category C: sklearn models consume pandas/numpy; native conversion at the model boundary
                     if isinstance(horizon_model, CatBoostRegressor) and isinstance(
                         model_x, pl_DataFrame
                     ):
@@ -1804,6 +1814,7 @@ class TimeSeries:
         values = values.astype(self.ga.data.dtype, copy=False)
         self._check_aligned_ends()
         if self._pooled_states:
+            # Category C: pd.Index guard before from_native
             uids_nw = pd.Series(uids) if isinstance(uids, pd.Index) else uids
             new_ids_nw = pd.Series(new_ids) if isinstance(new_ids, pd.Index) else new_ids
             expected_count = len(

--- a/mlforecast/core.py
+++ b/mlforecast/core.py
@@ -753,16 +753,15 @@ class TimeSeries:
         feature_cols = list(bucket_vals.keys())
         if not feature_cols:
             return
-        if isinstance(df, pd.DataFrame):
-            join_df = bucket_df[join_cols].copy()
-            for name, vals in bucket_vals.items():
-                join_df[name] = vals
-            left = df[join_cols]
-        else:
-            join_df = bucket_df.select(join_cols)
-            for name, vals in bucket_vals.items():
-                join_df = join_df.with_columns(pl.Series(name=name, values=vals))
-            left = df.select(join_cols)
+        nw_bucket = nw.from_native(bucket_df, eager_only=True)
+        backend = nw.get_native_namespace(nw_bucket)
+        join_df = nw_bucket.select(join_cols)
+        for name, vals in bucket_vals.items():
+            join_df = join_df.with_columns(
+                nw.new_series(name, vals, backend=backend).alias(name)
+            )
+        join_df = join_df.to_native()
+        left = nw.from_native(df, eager_only=True).select(join_cols).to_native()
         joined = nw.to_native(
             _order_preserving_left_join(
                 nw.from_native(left), nw.from_native(join_df), on=join_cols
@@ -1297,12 +1296,10 @@ class TimeSeries:
 
     def _get_future_ids(self, h: int):
         if isinstance(self.uids, pl_Series):
-            uids = pl.concat([self.uids for _ in range(h)]).sort()
-        else:
-            uids = pd.Series(
-                np.repeat(self.uids, h), name=self.id_col, dtype=self.uids.dtype
-            )
-        return uids
+            idxs = np.repeat(np.arange(len(self.uids)), h)
+            return self.uids.gather(idxs).sort()
+        repeated = np.repeat(np.asarray(self.uids), h)
+        return pd.Series(repeated, name=self.id_col, dtype=self.uids.dtype)
 
     def _get_predictions(self) -> DataFrame:
         """Get all the predicted values with their corresponding ids and datestamps."""

--- a/mlforecast/core.py
+++ b/mlforecast/core.py
@@ -992,6 +992,7 @@ class TimeSeries:
                         unique_dates, feature
                     ).items():
                         df[feat_name] = feat_vals[restore_idxs]
+            # Category C: backend-specific date-feature fast path (pandas positional-map + polars expr build); kept for performance
             elif isinstance(df, pl_DataFrame):
                 exprs = []
                 nw_feats: Dict[str, Any] = {}
@@ -1291,6 +1292,7 @@ class TimeSeries:
             ).items():
                 features[feat_name] = feat_vals
 
+        # Category C: native-container boundary — uids/df constructor selected per backend
         if isinstance(self.last_dates, pl_Series):
             df_constructor = pl_DataFrame
         else:
@@ -1302,6 +1304,7 @@ class TimeSeries:
         return np.array(self.y_pred).ravel("F")
 
     def _get_future_ids(self, h: int):
+        # Category C: native-container boundary — uids/df constructor selected per backend
         if isinstance(self.uids, pl_Series):
             idxs = np.repeat(np.arange(len(self.uids)), h)
             return self.uids.gather(idxs).sort()
@@ -1311,6 +1314,7 @@ class TimeSeries:
     def _get_predictions(self) -> DataFrame:
         """Get all the predicted values with their corresponding ids and datestamps."""
         h = len(self.y_pred)
+        # Category C: native-container boundary — uids/df constructor selected per backend
         if isinstance(self.uids, pl_Series):
             df_constructor = pl_DataFrame
         else:
@@ -1417,6 +1421,7 @@ class TimeSeries:
 
     def _predict_setup(self) -> None:
         # TODO: move to utils
+        # Category C: native-container boundary — clone/copy method selected per backend
         if isinstance(self.last_dates, pl_Series):
             self.curr_dates = self.last_dates.clone()
         else:

--- a/mlforecast/core.py
+++ b/mlforecast/core.py
@@ -1392,7 +1392,9 @@ class TimeSeries:
             if X_row is None:
                 X_row = self._current_step_rows(X_df)
             new_x = ufp.horizontal_concat([new_x, X_row])
-        null_any = nw.from_native(new_x, eager_only=True).select(nw.all().is_null().any())
+        null_any = nw.from_native(new_x, eager_only=True).select(
+            nw.all().is_null().any()
+        )
         cols_with_nulls = [c for c in null_any.columns if null_any[c][0]]
         if cols_with_nulls:
             warnings.warn(f"Found null values in {', '.join(cols_with_nulls)}.")
@@ -1821,7 +1823,9 @@ class TimeSeries:
         if self._pooled_states:
             # Category C: pd.Index guard before from_native
             uids_nw = pd.Series(uids) if isinstance(uids, pd.Index) else uids
-            new_ids_nw = pd.Series(new_ids) if isinstance(new_ids, pd.Index) else new_ids
+            new_ids_nw = (
+                pd.Series(new_ids) if isinstance(new_ids, pd.Index) else new_ids
+            )
             expected_count = len(
                 set(nw.from_native(uids_nw, series_only=True).to_list())
                 | set(nw.from_native(new_ids_nw, series_only=True).to_list())

--- a/mlforecast/core.py
+++ b/mlforecast/core.py
@@ -1297,8 +1297,46 @@ class TimeSeries:
             df_constructor = pl_DataFrame
         else:
             df_constructor = pd.DataFrame
+        self._feature_null_cols = self._null_cols_in_feature_values(
+            features, nan_is_null=df_constructor is pd.DataFrame
+        )
         features_df = df_constructor(features)[self.features]
         return ufp.horizontal_concat([self.static_features_, features_df])
+
+    def _null_cols_in_feature_values(
+        self, features: Dict[str, Any], nan_is_null: bool
+    ) -> List[str]:
+        """Names of computed features containing nulls, in ``self.features`` order.
+
+        Runs once per horizon step, so it checks the raw feature values
+        (numpy arrays or native series) before the frame is assembled instead
+        of scanning the assembled frame, keeping the per-step null diagnostic
+        vectorized. NaN counts as null only when ``nan_is_null`` (the pandas
+        backend), matching each backend's null semantics.
+        """
+        null_names = set()
+        for name, vals in features.items():
+            if isinstance(vals, np.ndarray):
+                kind = vals.dtype.kind
+                if kind == "f":
+                    has_null = nan_is_null and bool(np.isnan(vals).any())
+                elif kind in "Mm":
+                    has_null = bool(np.isnat(vals).any())
+                elif kind == "O":
+                    has_null = bool(pd.isnull(vals).any())
+                else:
+                    # int/uint/bool arrays can't hold nulls
+                    has_null = False
+            else:
+                try:
+                    has_null = bool(
+                        nw.from_native(vals, series_only=True).is_null().any()
+                    )
+                except TypeError:
+                    has_null = bool(pd.isnull(np.asarray(vals)).any())
+            if has_null:
+                null_names.add(name)
+        return [c for c in self.features if c in null_names]
 
     def _get_raw_predictions(self) -> np.ndarray:
         return np.array(self.y_pred).ravel("F")
@@ -1388,14 +1426,33 @@ class TimeSeries:
         if X_df is not None:
             X_row = self._update_partition_assignments(X_df)
         new_x = self._update_features()
+        # statics were scanned in _predict_setup and computed features while
+        # building them in _update_features; assembled here in new_x column
+        # order (statics, features, X_row) so the warning matches a full scan
+        cols_with_nulls = self._static_null_cols + self._feature_null_cols
         if X_df is not None:
             if X_row is None:
                 X_row = self._current_step_rows(X_df)
+            if self._xdf_null_cols is None:
+                # X_df is fixed for the whole predict; scan it once so the
+                # common no-nulls case skips the per-step check entirely
+                xdf_nw = nw.from_native(X_df, eager_only=True)
+                if xdf_nw.columns:
+                    xdf_null_counts = xdf_nw.null_count().row(0)
+                    self._xdf_null_cols = [
+                        c for c, n in zip(xdf_nw.columns, xdf_null_counts) if n
+                    ]
+                else:
+                    self._xdf_null_cols = []
+            if self._xdf_null_cols:
+                row_nw = nw.from_native(X_row, eager_only=True).select(
+                    self._xdf_null_cols
+                )
+                row_null_counts = row_nw.null_count().row(0)
+                cols_with_nulls += [
+                    c for c, n in zip(self._xdf_null_cols, row_null_counts) if n
+                ]
             new_x = ufp.horizontal_concat([new_x, X_row])
-        null_any = nw.from_native(new_x, eager_only=True).select(
-            nw.all().is_null().any()
-        )
-        cols_with_nulls = [c for c in null_any.columns if null_any[c][0]]
         if cols_with_nulls:
             warnings.warn(f"Found null values in {', '.join(cols_with_nulls)}.")
         self._h += 1
@@ -1431,6 +1488,18 @@ class TimeSeries:
         self.test_dates: List[Union[pd.Index, pl_Series]] = []
         self.y_pred = []
         self._h = 0
+        # Null-diagnostic state for _get_features_for_next_step. Statics are
+        # fixed for the whole predict, so scan them once here (boundary)
+        # instead of once per horizon step (hot loop).
+        self._feature_null_cols: List[str] = []
+        self._xdf_null_cols: Optional[List[str]] = None
+        self._static_null_cols: List[str] = []
+        statics_nw = nw.from_native(self.static_features_, eager_only=True)
+        if statics_nw.columns:
+            static_null_counts = statics_nw.null_count().row(0)
+            self._static_null_cols = [
+                c for c, n in zip(statics_nw.columns, static_null_counts) if n
+            ]
 
     def _predict_recursive(
         self,

--- a/mlforecast/core.py
+++ b/mlforecast/core.py
@@ -235,7 +235,7 @@ def _static_feature_changes_over_time(start_series, end_series) -> bool:
     return bool(changed.fill_null(False).any())
 
 
-# Category C: native-container boundary for observable uids/last_dates (pd.Index/pl.Series); tests rely on these types
+# native-container boundary for observable uids/last_dates (pd.Index/pl.Series); tests rely on these types
 def _to_native_uids(values, *, df):
     """Wrap ids/dates into the backend-native container mlforecast exposes as
     ``TimeSeries.uids`` / ``TimeSeries.last_dates``.
@@ -410,7 +410,7 @@ class TimeSeries:
         """Check that all series end at the same timestamp when using pooled lag transforms."""
         if not self._get_pooled_tfms():
             return
-        # Category C: pd.Index is not a narwhals input type; wrap to Series before from_native
+        # pd.Index is not a narwhals input type; wrap to Series before from_native
         last_dates = (
             pd.Series(self.last_dates)
             if isinstance(self.last_dates, pd.Index)
@@ -790,22 +790,22 @@ class TimeSeries:
         if callable(feature):
             feat_name = feature.__name__
             feat_vals = feature(dates)
-            # Category C: callable-returned native types have no narwhals equivalent
+            # callable-returned native types have no narwhals equivalent
             if isinstance(feat_vals, pd.DataFrame):
                 return {col: np.asarray(feat_vals[col]) for col in feat_vals.columns}
-            # Category C: callable-returned native types have no narwhals equivalent
+            # callable-returned native types have no narwhals equivalent
             if isinstance(feat_vals, (pd.Index, pd.Series)):
                 feat_vals = np.asarray(feat_vals)
             return {feat_name: feat_vals}
 
         # regular string feature
         feat_name = feature
-        # Category C: DatetimeIndex date-attribute access has no narwhals equivalent
+        # DatetimeIndex date-attribute access has no narwhals equivalent
         if isinstance(dates, pd.DatetimeIndex):
             if feature in ("week", "weekofyear"):
                 dates = dates.isocalendar()
             feat_vals = getattr(dates, feature)
-            # Category C: DatetimeIndex date-attribute access has no narwhals equivalent
+            # DatetimeIndex date-attribute access has no narwhals equivalent
             if isinstance(feat_vals, (pd.Index, pd.Series)):
                 feat_vals = np.asarray(feat_vals)
                 feat_dtype = date_features_dtypes.get(feature)
@@ -987,7 +987,7 @@ class TimeSeries:
         ]
         if date_features:
             unique_dates = df[self.time_col].unique()
-            # Category C: pandas positional-map fast path; narwhals rewrite would regress this hot path
+            # pandas positional-map fast path; narwhals rewrite would regress this hot path
             if isinstance(df, pd.DataFrame):
                 # all kinds of trickery to make this fast
                 unique_dates = pd.Index(unique_dates)
@@ -998,7 +998,7 @@ class TimeSeries:
                         unique_dates, feature
                     ).items():
                         df[feat_name] = feat_vals[restore_idxs]
-            # Category C: backend-specific date-feature fast path (pandas positional-map + polars expr build); kept for performance
+            # backend-specific date-feature fast path (pandas positional-map + polars expr build); kept for performance
             elif isinstance(df, pl_DataFrame):
                 exprs = []
                 nw_feats: Dict[str, Any] = {}
@@ -1315,7 +1315,7 @@ class TimeSeries:
                 ).items():
                     features[feat_name] = feat_vals
 
-        # Category C: native-container boundary — uids/df constructor selected per backend
+        # native-container boundary — uids/df constructor selected per backend
         if isinstance(self.last_dates, pl_Series):
             df_constructor = pl_DataFrame
         else:
@@ -1367,7 +1367,7 @@ class TimeSeries:
         return np.array(self.y_pred).ravel("F")
 
     def _get_future_ids(self, h: int):
-        # Category C: native-container boundary — uids/df constructor selected per backend
+        # native-container boundary — uids/df constructor selected per backend
         if isinstance(self.uids, pl_Series):
             idxs = np.repeat(np.arange(len(self.uids)), h)
             return self.uids.gather(idxs).sort()
@@ -1377,7 +1377,7 @@ class TimeSeries:
     def _get_predictions(self) -> DataFrame:
         """Get all the predicted values with their corresponding ids and datestamps."""
         h = len(self.y_pred)
-        # Category C: native-container boundary — uids/df constructor selected per backend
+        # native-container boundary — uids/df constructor selected per backend
         if isinstance(self.uids, pl_Series):
             df_constructor = pl_DataFrame
         else:
@@ -1510,7 +1510,7 @@ class TimeSeries:
 
     def _predict_setup(self) -> None:
         # TODO: move to utils
-        # Category C: native-container boundary — clone/copy method selected per backend
+        # native-container boundary — clone/copy method selected per backend
         if isinstance(self.last_dates, pl_Series):
             self.curr_dates = self.last_dates.clone()
         else:
@@ -1576,7 +1576,7 @@ class TimeSeries:
                     if before_predict_callback is not None:
                         new_x = before_predict_callback(new_x)
                     model_x = new_x
-                    # Category C: sklearn models consume pandas/numpy; native conversion at the model boundary
+                    # sklearn models consume pandas/numpy; native conversion at the model boundary
                     if isinstance(model, CatBoostRegressor) and isinstance(
                         new_x, pl_DataFrame
                     ):
@@ -1645,7 +1645,7 @@ class TimeSeries:
                     ufp.offset_times(self.curr_dates, self.freq, h + 1)
                     for h in horizons_to_predict
                 ]
-                # Category C: backend-specific date-matrix build at prediction assembly
+                # backend-specific date-matrix build at prediction assembly
                 # Stack: each row is a series, each col is a horizon
                 dates_matrix = pl.DataFrame(dates_per_horizon).transpose()
                 # Flatten row by row: [s0_h0, s0_h1, ..., s1_h0, s1_h1, ...]
@@ -1715,7 +1715,7 @@ class TimeSeries:
                             )
                             model_x = new_x[h_cols]
                     horizon_model = model[h]
-                    # Category C: sklearn models consume pandas/numpy; native conversion at the model boundary
+                    # sklearn models consume pandas/numpy; native conversion at the model boundary
                     if isinstance(horizon_model, CatBoostRegressor) and isinstance(
                         model_x, pl_DataFrame
                     ):
@@ -1950,7 +1950,7 @@ class TimeSeries:
         values = values.astype(self.ga.data.dtype, copy=False)
         self._check_aligned_ends()
         if self._pooled_states:
-            # Category C: pd.Index guard before from_native
+            # pd.Index guard before from_native
             uids_nw = pd.Series(uids) if isinstance(uids, pd.Index) else uids
             new_ids_nw = (
                 pd.Series(new_ids) if isinstance(new_ids, pd.Index) else new_ids

--- a/mlforecast/core.py
+++ b/mlforecast/core.py
@@ -390,10 +390,12 @@ class TimeSeries:
         """Check that all series end at the same timestamp when using pooled lag transforms."""
         if not self._get_pooled_tfms():
             return
-        if isinstance(self.last_dates, pd.Index):
-            aligned = self.last_dates.nunique() == 1
-        else:
-            aligned = self.last_dates.n_unique() == 1
+        last_dates = (
+            pd.Series(self.last_dates)
+            if isinstance(self.last_dates, pd.Index)
+            else self.last_dates
+        )
+        aligned = nw.from_native(last_dates, series_only=True).n_unique() == 1
         if not aligned:
             raise ValueError(
                 "Pooled lag transforms require all series to end at the same timestamp "
@@ -923,9 +925,9 @@ class TimeSeries:
                     "These series won't show up if you use `MLForecast.forecast_fitted_values()`.\n"
                     "You can set `dropna=False` or use transformations that require less samples to mitigate this"
                 )
-        elif isinstance(df, pd.DataFrame):
-            # we'll be assigning columns below, so we need to copy
-            df = df.copy(deep=False)
+        else:
+            # we'll be assigning columns below; copy_if_pandas is a no-op on polars (immutable)
+            df = ufp.copy_if_pandas(df, deep=False)
 
         # once we've computed the features and target we can slice the series
         update_samples = [
@@ -1373,12 +1375,8 @@ class TimeSeries:
             if X_row is None:
                 X_row = self._current_step_rows(X_df)
             new_x = ufp.horizontal_concat([new_x, X_row])
-        if isinstance(new_x, pd.DataFrame):
-            nulls = new_x.isnull().any()
-            cols_with_nulls = nulls[nulls].index.tolist()
-        else:
-            nulls = new_x.select(pl.all().is_null().any())
-            cols_with_nulls = [k for k, v in nulls.to_dicts()[0].items() if v]
+        null_any = nw.from_native(new_x, eager_only=True).select(nw.all().is_null().any())
+        cols_with_nulls = [c for c in null_any.columns if null_any[c][0]]
         if cols_with_nulls:
             warnings.warn(f"Found null values in {', '.join(cols_with_nulls)}.")
         self._h += 1
@@ -1799,26 +1797,21 @@ class TimeSeries:
         values = values.astype(self.ga.data.dtype, copy=False)
         self._check_aligned_ends()
         if self._pooled_states:
-            if isinstance(df, pd.DataFrame):
-                expected_ids = pd.Index(uids).union(pd.Index(new_ids))
-                expected_count = len(expected_ids)
-                counts = df.groupby(self.time_col, observed=True)[self.id_col].nunique()
-                bad_times = counts[counts != expected_count]
-                if not bad_times.empty:
-                    raise ValueError(
-                        "Pooled lag transforms require updates to include all series for each timestamp."
-                    )
-            else:
-                expected_ids = pl.concat([pl.Series(uids), pl.Series(new_ids)]).unique()
-                expected_count = expected_ids.len()
-                counts = df.group_by(self.time_col).agg(
-                    pl.col(self.id_col).n_unique().alias("_n_ids")
+            uids_nw = pd.Series(uids) if isinstance(uids, pd.Index) else uids
+            new_ids_nw = pd.Series(new_ids) if isinstance(new_ids, pd.Index) else new_ids
+            expected_count = len(
+                set(nw.from_native(uids_nw, series_only=True).to_list())
+                | set(nw.from_native(new_ids_nw, series_only=True).to_list())
+            )
+            counts = (
+                nw.from_native(df, eager_only=True)
+                .group_by(self.time_col)
+                .agg(nw.col(self.id_col).n_unique().alias("_n_ids"))
+            )
+            if counts.filter(nw.col("_n_ids") != expected_count).shape[0] > 0:
+                raise ValueError(
+                    "Pooled lag transforms require updates to include all series for each timestamp."
                 )
-                bad_times = counts.filter(pl.col("_n_ids") != expected_count)
-                if bad_times.height:
-                    raise ValueError(
-                        "Pooled lag transforms require updates to include all series for each timestamp."
-                    )
         if validate_new_data:
             self._validate_new_df(df=df)
         id_counts = ufp.counts_by_id(df, self.id_col)

--- a/mlforecast/data_validation.py
+++ b/mlforecast/data_validation.py
@@ -10,8 +10,7 @@ import reprlib
 from typing import Tuple, Union
 
 import narwhals as nw
-import pandas as pd
-from utilsforecast.compat import DFType, pl
+from utilsforecast.compat import DFType
 from utilsforecast.processing import offset_times
 
 
@@ -114,10 +113,9 @@ def validate_continuity(
         ]
     )
 
-    # offset_times accepts Union[int, np.ndarray] for n; convert pandas Series to numpy
+    # offset_times accepts a native numpy array (pandas) or a native Series (polars);
+    # `.to_native()` yields the right type per backend without an explicit branch
     n_steps = (stats["_n_unique"] - 1).to_native()
-    if isinstance(n_steps, pd.Series):
-        n_steps = n_steps.to_numpy()
 
     expected_max_native = offset_times(stats["_min"].to_native(), freq, n_steps)
     expected_max_nw = nw.from_native(expected_max_native, series_only=True).alias(
@@ -163,10 +161,11 @@ def validate_update_df(
     Raises:
         ValueError: If any series has an invalid start date or internal gaps/duplicates.
     """
-    if isinstance(df, pd.DataFrame):
-        last_dates_df = pd.DataFrame({id_col: uids, "_last": last_dates})
-    else:
-        last_dates_df = pl.DataFrame({id_col: uids, "_last": last_dates})
+    # build the frame in df's backend so the downstream join stays backend-consistent
+    backend = nw.get_native_namespace(nw.from_native(df, eager_only=True))
+    last_dates_df = nw.from_dict(
+        {id_col: list(uids), "_last": list(last_dates)}, backend=backend
+    ).to_native()
 
     has_issues, bad = validate_update_start_dates(
         df, id_col, time_col, last_dates_df, freq

--- a/mlforecast/data_validation.py
+++ b/mlforecast/data_validation.py
@@ -10,8 +10,18 @@ import reprlib
 from typing import Tuple, Union
 
 import narwhals as nw
+import pandas as pd
 from utilsforecast.compat import DFType
 from utilsforecast.processing import offset_times
+
+
+def _index_to_series(x):
+    """Wrap a ``pd.Index`` into a ``pd.Series`` (pass anything else through).
+
+    ``pd.Index`` is not a valid narwhals input, so this normalizes
+    ``uids``/``last_dates`` before ``nw.from_native``.
+    """
+    return pd.Series(x) if isinstance(x, pd.Index) else x
 
 
 def validate_update_start_dates(
@@ -161,11 +171,13 @@ def validate_update_df(
     Raises:
         ValueError: If any series has an invalid start date or internal gaps/duplicates.
     """
-    # build the frame in df's backend so the downstream join stays backend-consistent
-    backend = nw.get_native_namespace(nw.from_native(df, eager_only=True))
-    last_dates_df = nw.from_dict(
-        {id_col: list(uids), "_last": list(last_dates)}, backend=backend
-    ).to_native()
+    # build the frame from the native series so dtypes survive (categorical ids,
+    # nanosecond-precision timestamps); a python-list round-trip would lose both
+    uids_nw = nw.from_native(_index_to_series(uids), series_only=True).alias(id_col)
+    last_nw = nw.from_native(_index_to_series(last_dates), series_only=True).alias(
+        "_last"
+    )
+    last_dates_df = uids_nw.to_frame().with_columns(last_nw).to_native()
 
     has_issues, bad = validate_update_start_dates(
         df, id_col, time_col, last_dates_df, freq

--- a/mlforecast/forecast.py
+++ b/mlforecast/forecast.py
@@ -512,7 +512,7 @@ class MLForecast:
                     fit_kwargs["sample_weight"] = X[weight_col]
                     X = ufp.drop_columns(X, weight_col)
             if isinstance(model, CatBoostRegressor):
-                # Category C: model input boundary
+                # CatBoost consumes pandas, not polars; convert at the model input boundary
                 if isinstance(X, pl_DataFrame):
                     X = X.to_pandas()
                 sample_weight = fit_kwargs.get("sample_weight")
@@ -862,14 +862,14 @@ class MLForecast:
                 )
             train_df = self._fitted_train_df_
 
-        # Category C: pandas-only algorithm; converts to pandas at its boundary
+        # pandas-only algorithm; converts to pandas at its boundary
         if isinstance(train_df, pd.DataFrame):
             train_pd = train_df.copy()
         else:
             train_pd = train_df.to_pandas()
 
         one_step = self.fcst_fitted_values_
-        # Category C: pandas-only algorithm; converts to pandas at its boundary
+        # pandas-only algorithm; converts to pandas at its boundary
         if isinstance(one_step, pd.DataFrame):
             one_step_pd = one_step[[self.ts.id_col, self.ts.time_col]].copy()
         else:
@@ -892,7 +892,7 @@ class MLForecast:
             exclude.add(self.ts.weight_col)
         dynamic = [c for c in train_pd.columns if c not in exclude]
         model_names = list(self.models_.keys())
-        # Category C: pandas-only algorithm; converts to pandas at its boundary
+        # pandas-only algorithm; converts to pandas at its boundary
         if isinstance(self.ts.static_features_, pd.DataFrame):
             static_features_pd = self.ts.static_features_.copy(deep=True)
         else:
@@ -1272,7 +1272,7 @@ class MLForecast:
                 res_pd = self._compute_recursive_fitted_values_on_demand(
                     h, train_df=train_df
                 )
-                # Category C: convert the pandas-only recursive result back to the origin backend
+                # convert the pandas-only recursive result back to the origin backend
                 if isinstance(self.fcst_fitted_values_, pd.DataFrame):
                     res = res_pd
                 else:

--- a/mlforecast/forecast.py
+++ b/mlforecast/forecast.py
@@ -64,12 +64,18 @@ _get_transfer_method_spec = get_transfer_method_spec
 
 
 def _ensure_h_int64(res):
-    """Cast the ``h`` column to Int64, preserving the input backend."""
-    return (
+    """Cast the ``h`` column to Int64, preserving the input backend.
+
+    Deep-copies the pandas result so callers can mutate it without writing
+    through to the cached ``fcst_fitted_values_`` (narwhals' ``with_columns``
+    shares column buffers on pandas without copy-on-write).
+    """
+    res = (
         nw.from_native(res, eager_only=True)
         .with_columns(nw.col("h").cast(nw.Int64))
         .to_native()
     )
+    return ufp.copy_if_pandas(res, deep=True)
 
 
 def _frozen_backtest(

--- a/mlforecast/forecast.py
+++ b/mlforecast/forecast.py
@@ -1546,10 +1546,13 @@ class MLForecast:
                     )
                     warnings.warn(warn_msg, UserWarning)
                 else:
-                    if isinstance(self._cs_df, pl_DataFrame):
-                        cs_ids = set(self._cs_df[self.ts.id_col].unique().to_list())
-                    else:
-                        cs_ids = set(self._cs_df[self.ts.id_col].unique().tolist())
+                    cs_ids = set(
+                        nw.from_native(self._cs_df, eager_only=True)[
+                            self.ts.id_col
+                        ]
+                        .unique()
+                        .to_list()
+                    )
                     if ids is None:
                         active_ids = set(self.ts.uids)
                         if cs_ids != active_ids and new_df is None:

--- a/mlforecast/forecast.py
+++ b/mlforecast/forecast.py
@@ -510,6 +510,7 @@ class MLForecast:
                     fit_kwargs["sample_weight"] = X[weight_col]
                     X = ufp.drop_columns(X, weight_col)
             if isinstance(model, CatBoostRegressor):
+                # Category C: model input boundary
                 if isinstance(X, pl_DataFrame):
                     X = X.to_pandas()
                 sample_weight = fit_kwargs.get("sample_weight")
@@ -859,12 +860,14 @@ class MLForecast:
                 )
             train_df = self._fitted_train_df_
 
+        # Category C: pandas-only algorithm; converts to pandas at its boundary
         if isinstance(train_df, pd.DataFrame):
             train_pd = train_df.copy()
         else:
             train_pd = train_df.to_pandas()
 
         one_step = self.fcst_fitted_values_
+        # Category C: pandas-only algorithm; converts to pandas at its boundary
         if isinstance(one_step, pd.DataFrame):
             one_step_pd = one_step[[self.ts.id_col, self.ts.time_col]].copy()
         else:
@@ -887,6 +890,7 @@ class MLForecast:
             exclude.add(self.ts.weight_col)
         dynamic = [c for c in train_pd.columns if c not in exclude]
         model_names = list(self.models_.keys())
+        # Category C: pandas-only algorithm; converts to pandas at its boundary
         if isinstance(self.ts.static_features_, pd.DataFrame):
             static_features_pd = self.ts.static_features_.copy(deep=True)
         else:
@@ -1264,6 +1268,7 @@ class MLForecast:
                 res_pd = self._compute_recursive_fitted_values_on_demand(
                     h, train_df=train_df
                 )
+                # Category C: convert the pandas-only recursive result back to the origin backend
                 if isinstance(self.fcst_fitted_values_, pd.DataFrame):
                     res = res_pd
                 else:

--- a/mlforecast/forecast.py
+++ b/mlforecast/forecast.py
@@ -65,9 +65,11 @@ _get_transfer_method_spec = get_transfer_method_spec
 
 def _ensure_h_int64(res):
     """Cast the ``h`` column to Int64, preserving the input backend."""
-    return nw.from_native(res, eager_only=True).with_columns(
-        nw.col("h").cast(nw.Int64)
-    ).to_native()
+    return (
+        nw.from_native(res, eager_only=True)
+        .with_columns(nw.col("h").cast(nw.Int64))
+        .to_native()
+    )
 
 
 def _frozen_backtest(
@@ -1237,7 +1239,9 @@ class MLForecast:
                     "Please refit the model with the current version."
                 )
             res = ufp.drop_index_if_pandas(
-                nw.to_native(nw.from_native(res, eager_only=True).filter(nw.col("h") == h))
+                nw.to_native(
+                    nw.from_native(res, eager_only=True).filter(nw.col("h") == h)
+                )
             )
             available = sorted(
                 nw.from_native(self.fcst_fitted_values_, eager_only=True)["h"]
@@ -1547,9 +1551,7 @@ class MLForecast:
                     warnings.warn(warn_msg, UserWarning)
                 else:
                     cs_ids = set(
-                        nw.from_native(self._cs_df, eager_only=True)[
-                            self.ts.id_col
-                        ]
+                        nw.from_native(self._cs_df, eager_only=True)[self.ts.id_col]
                         .unique()
                         .to_list()
                     )

--- a/mlforecast/forecast.py
+++ b/mlforecast/forecast.py
@@ -63,6 +63,13 @@ _get_conformal_method = get_conformal_method  # backward compat
 _get_transfer_method_spec = get_transfer_method_spec
 
 
+def _ensure_h_int64(res):
+    """Cast the ``h`` column to Int64, preserving the input backend."""
+    return nw.from_native(res, eager_only=True).with_columns(
+        nw.col("h").cast(nw.Int64)
+    ).to_native()
+
+
 def _frozen_backtest(
     fcst: "MLForecast",
     new_df: DFType,
@@ -1214,12 +1221,7 @@ class MLForecast:
             res = self.fcst_fitted_values_
             if "h" not in res.columns:
                 res = ufp.assign_columns(res, "h", np.int64(h))
-            if isinstance(res, pd.DataFrame):
-                res = res.copy()
-                res["h"] = res["h"].astype(np.int64)
-            else:
-                res = res.with_columns(pl.col("h").cast(pl.Int64))
-            return res
+            return _ensure_h_int64(res)
 
         first_model = next(iter(self.models_.values()))
         is_direct = isinstance(first_model, dict)
@@ -1230,12 +1232,14 @@ class MLForecast:
                     "Direct fitted values are missing horizon information. "
                     "Please refit the model with the current version."
                 )
-            if isinstance(res, pd.DataFrame):
-                res = res[res["h"].eq(h)].reset_index(drop=True)
-                available = sorted(self.fcst_fitted_values_["h"].unique().tolist())
-            else:
-                res = res.filter(pl.col("h") == h)
-                available = sorted(self.fcst_fitted_values_["h"].unique().to_list())
+            res = nw.to_native(
+                nw.from_native(res, eager_only=True).filter(nw.col("h") == h)
+            )
+            available = sorted(
+                nw.from_native(self.fcst_fitted_values_, eager_only=True)["h"]
+                .unique()
+                .to_list()
+            )
             if len(res) == 0:
                 raise ValueError(
                     f"No fitted values found for h={h}. Available horizons: {available}."
@@ -1266,11 +1270,7 @@ class MLForecast:
                     res = pl.from_pandas(res_pd)
         if "h" not in res.columns:
             res = ufp.assign_columns(res, "h", np.int64(h))
-        if isinstance(res, pd.DataFrame):
-            res = res.copy()
-            res["h"] = res["h"].astype(np.int64)
-        else:
-            res = res.with_columns(pl.col("h").cast(pl.Int64))
+        res = _ensure_h_int64(res)
         if level is not None:
             res = ufp.add_insample_levels(
                 res,

--- a/mlforecast/forecast.py
+++ b/mlforecast/forecast.py
@@ -1232,8 +1232,8 @@ class MLForecast:
                     "Direct fitted values are missing horizon information. "
                     "Please refit the model with the current version."
                 )
-            res = nw.to_native(
-                nw.from_native(res, eager_only=True).filter(nw.col("h") == h)
+            res = ufp.drop_index_if_pandas(
+                nw.to_native(nw.from_native(res, eager_only=True).filter(nw.col("h") == h))
             )
             available = sorted(
                 nw.from_native(self.fcst_fitted_values_, eager_only=True)["h"]

--- a/mlforecast/optimization.py
+++ b/mlforecast/optimization.py
@@ -5,12 +5,12 @@ import copy
 import warnings
 from typing import Any, Callable, Dict, Optional, Union, List, Tuple
 
+import narwhals as nw
 import numpy as np
-import pandas as pd
 import optuna
 import utilsforecast.processing as ufp
 from sklearn.base import BaseEstimator, clone
-from utilsforecast.compat import DataFrame, pl
+from utilsforecast.compat import DataFrame
 
 from . import MLForecast
 from .compat import CatBoostRegressor
@@ -35,32 +35,12 @@ def _get_categorical_static_features(
             UserWarning,
         )
     static_features = [feature for feature in static_features if feature in df.columns]
-    if isinstance(df, pd.DataFrame):
-        return [
-            feature
-            for feature in static_features
-            if (
-                isinstance(df[feature].dtype, pd.CategoricalDtype)
-                or pd.api.types.is_object_dtype(df[feature].dtype)
-                or pd.api.types.is_string_dtype(df[feature].dtype)
-            )
-        ]
-    if pl is not None and isinstance(df, pl.DataFrame):
-        categorical_dtypes = [pl.Categorical]
-        if hasattr(pl, "Enum"):
-            categorical_dtypes.append(pl.Enum)
-        if hasattr(pl, "String"):
-            categorical_dtypes.append(pl.String)
-        if hasattr(pl, "Utf8"):
-            categorical_dtypes.append(pl.Utf8)
-        schema = df.schema
-        return [
-            feature
-            for feature in static_features
-            if schema.get(feature) is not None
-            and isinstance(schema[feature], tuple(categorical_dtypes))
-        ]
-    return []
+    schema = nw.from_native(df, eager_only=True).schema
+    return [
+        feature
+        for feature in static_features
+        if schema[feature] in (nw.Categorical, nw.Enum, nw.String)
+    ]
 
 
 def mlforecast_objective(

--- a/mlforecast/optimization.py
+++ b/mlforecast/optimization.py
@@ -39,7 +39,7 @@ def _get_categorical_static_features(
     return [
         feature
         for feature in static_features
-        if schema[feature] in (nw.Categorical, nw.Enum, nw.String)
+        if schema[feature] in (nw.Categorical, nw.Enum, nw.String, nw.Object)
     ]
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2364,3 +2364,123 @@ def test_non_jitted_tfms(series):
         ts.predict({"naive": NaiveModel()}, horizon=5, before_predict_callback=cbk)
     feats = cbk.get_features()
     assert_same_as_native(feats)
+
+
+@pytest.mark.parametrize("engine", ["pandas", "polars"])
+@pytest.mark.parametrize("equal_ends", [True, False])
+def test_predict_date_features_per_series(engine, equal_ends):
+    # uniform last dates take a broadcast fast path in _update_features;
+    # staggered last dates compute per-series. Both must yield the date
+    # feature of each series' own next timestamp at every step.
+    horizon = 3
+    series = generate_daily_series(
+        3, n_static_features=1, equal_ends=equal_ends, engine=engine
+    )
+    freq = "1d" if engine == "polars" else "D"
+    ts = TimeSeries(freq=freq, lags=[1], date_features=["day"])
+    ts.fit_transform(series, id_col="unique_id", time_col="ds", target_col="y")
+    cbk = SaveFeatures()
+    ts.predict({"Naive": NaiveModel()}, horizon, before_predict_callback=cbk)
+    feats = cbk.get_features()
+    if engine == "polars":
+        expected = np.concatenate(
+            [
+                ts.last_dates.dt.offset_by(f"{k}d").dt.day().to_numpy()
+                for k in range(1, horizon + 1)
+            ]
+        )
+    else:
+        expected = np.concatenate(
+            [
+                np.asarray((ts.last_dates + pd.Timedelta(days=k)).day)
+                for k in range(1, horizon + 1)
+            ]
+        )
+    np.testing.assert_array_equal(np.asarray(feats["day"]), expected)
+
+
+@pytest.mark.parametrize("engine", ["pandas", "polars"])
+def test_predict_warns_on_null_statics(engine):
+    series = generate_daily_series(
+        2, n_static_features=1, static_as_categorical=False, engine=engine
+    )
+    if engine == "polars":
+        first_uid = series["unique_id"][0]
+        series = series.with_columns(
+            pl.when(pl.col("unique_id") == first_uid)
+            .then(None)
+            .otherwise(pl.col("static_0"))
+            .alias("static_0")
+        )
+        freq = "1d"
+    else:
+        first_uid = series["unique_id"].iloc[0]
+        series.loc[series["unique_id"] == first_uid, "static_0"] = np.nan
+        freq = "D"
+    ts = TimeSeries(freq=freq, lags=[1])
+    ts.fit_transform(series, id_col="unique_id", time_col="ds", target_col="y")
+    with pytest.warns(UserWarning, match="Found null values in static_0"):
+        ts.predict({"Naive": NaiveModel()}, 2)
+
+
+def test_predict_warns_on_null_computed_features():
+    # a lag longer than every series produces NaN feature values during
+    # predict; pandas treats NaN as null so the diagnostic must fire
+    series = generate_daily_series(2, min_length=20, max_length=30)
+    ts = TimeSeries(freq="D", lags=[1, 50])
+    ts.fit_transform(
+        series, id_col="unique_id", time_col="ds", target_col="y", dropna=False
+    )
+    with pytest.warns(UserWarning, match="Found null values in lag50"):
+        ts.predict({"Naive": NaiveModel()}, 1)
+
+
+@pytest.mark.parametrize("engine", ["pandas", "polars"])
+def test_update_validation_categorical_ids(engine):
+    series = generate_daily_series(2, engine=engine)
+    if engine == "polars":
+        series = series.with_columns(pl.col("unique_id").cast(pl.Categorical))
+        freq = "1d"
+    else:
+        series["unique_id"] = series["unique_id"].astype("category")
+        freq = "D"
+    ts = TimeSeries(freq=freq, lags=[1])
+    ts.fit_transform(series, id_col="unique_id", time_col="ds", target_col="y")
+    if engine == "polars":
+        last_vals = series.join(
+            series.group_by("unique_id").agg(pl.col("ds").max()),
+            on=["unique_id", "ds"],
+        )
+        update = last_vals.with_columns(pl.col("ds").dt.offset_by("1d"))
+    else:
+        last_vals = series.groupby("unique_id", observed=True).tail(1).copy()
+        update = last_vals.assign(ds=last_vals["ds"] + pd.Timedelta(days=1))
+    ts.update(update, validate_new_data=True)
+
+
+def test_update_validation_polars_ns_timestamps():
+    # nanosecond-precision timestamps are not representable as python
+    # datetimes; validation must not round-trip them through python objects.
+    # n is chosen so the update's timestamp (n ns = 1us) crosses a
+    # microsecond boundary: a us-truncating round-trip would then expect a
+    # start of 0us and reject the valid update
+    n = 1000
+    times = pl.Series("ds", np.arange(n), dtype=pl.Int64).cast(pl.Datetime("ns"))
+    series = pl.DataFrame(
+        {
+            "unique_id": ["a"] * n + ["b"] * n,
+            "ds": pl.concat([times, times]),
+            "y": np.arange(2 * n, dtype=np.float64),
+        }
+    )
+    ts = TimeSeries(freq="1ns", lags=[1])
+    ts.fit_transform(series, id_col="unique_id", time_col="ds", target_col="y")
+    next_time = pl.Series("ds", [n], dtype=pl.Int64).cast(pl.Datetime("ns"))
+    update = pl.DataFrame(
+        {
+            "unique_id": ["a", "b"],
+            "ds": pl.concat([next_time, next_time]),
+            "y": [1.0, 2.0],
+        }
+    )
+    ts.update(update, validate_new_data=True)

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -11,6 +11,7 @@ import pytest
 import utilsforecast.processing as ufp
 import xgboost as xgb
 from sklearn import set_config
+from sklearn.ensemble import HistGradientBoostingRegressor
 from sklearn.linear_model import LinearRegression
 from utilsforecast.feature_engineering import fourier, time_features
 from utilsforecast.processing import match_if_categorical
@@ -2638,3 +2639,46 @@ def test_predict_x_df_missing_horizon_features(horizon_features_data):
 
     with pytest.raises(ValueError, match="X_df is missing future values"):
         fcst.predict(h=H, X_df=future_missing)
+
+
+def test_forecast_fitted_values_mutation_isolation():
+    # the returned frame must not share buffers with the cached fitted
+    # values; in-place mutation by the caller must not corrupt later calls
+    series = generate_daily_series(2, min_length=50, max_length=50)
+    fcst = MLForecast(models=[LinearRegression()], freq="D", lags=[1])
+    fcst.fit(series, fitted=True)
+    res1 = fcst.forecast_fitted_values()
+    expected = res1.copy(deep=True)
+    # .loc writes into the existing buffers (unlike column assignment, which
+    # replaces them), so this catches buffer sharing with the cache
+    res1.loc[:, "LinearRegression"] = -1.0
+    res1.loc[:, "h"] = -5
+    res2 = fcst.forecast_fitted_values()
+    pd.testing.assert_frame_equal(res2, expected)
+
+
+@pytest.mark.parametrize("engine", ["pandas", "polars"])
+def test_predict_warns_on_null_exog(engine):
+    series = generate_daily_series(2, engine=engine)
+    if engine == "polars":
+        series = series.with_columns(pl.lit(1.0).alias("ex1"))
+        freq = "1d"
+    else:
+        series = series.assign(ex1=1.0)
+        freq = "D"
+    # NaN-tolerant model so predict survives past the warning
+    fcst = MLForecast(
+        models=[HistGradientBoostingRegressor(max_iter=5)],
+        freq=freq,
+        lags=[1],
+    )
+    fcst.fit(series, static_features=[])
+    future = fcst.make_future_dataframe(2)
+    if engine == "polars":
+        future = future.with_columns(
+            pl.Series("ex1", [1.0, None, 2.0, None], dtype=pl.Float64)
+        )
+    else:
+        future["ex1"] = [1.0, np.nan, 2.0, np.nan]
+    with pytest.warns(UserWarning, match="Found null values in ex1"):
+        fcst.predict(2, X_df=future)

--- a/uv.lock
+++ b/uv.lock
@@ -2725,7 +2725,7 @@ wheels = [
 
 [[package]]
 name = "mlforecast"
-version = "1.0.31"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "cloudpickle" },


### PR DESCRIPTION
## Summary

Refactors the codebase to use [Narwhals](https://narwhals-dev.github.io/narwhals/) as a single dataframe-agnostic path instead of maintaining parallel pandas/polars branches. This removes most of the hand-written backend splits across `core.py`, `forecast.py`, `data_validation.py`, and `optimization.py`, leaving native-backend code only where it's genuinely required (see below).

Closes #577

## What changed

- **`data_validation.py` / `optimization.py`** — unified pandas/polars branches through narwhals (schema-based categorical detection, shared validation logic). Object-dtype columns are still treated as categorical to preserve pre-refactor behavior.
- **`core.py`** — centralized `uids`/`last_dates` native conversion into one helper, rewrote op-splits (bucket-join construction, date features, residuals) via narwhals, and reset the pandas index after the narwhals horizon filter so output matches the pre-refactor result exactly.
- **`forecast.py`** — unified fitted-values horizon cast/filter via narwhals.

## Native-backend code that was intentionally kept

Not every split was incidental duplication. A handful are performance- or compatibility-motivated and remain backend-specific, now with plain-English comments explaining why (e.g. narwhals has no equivalent for `DatetimeIndex` attribute access; sklearn/CatBoost models consume pandas/numpy at the model boundary; the per-step null check stays vectorized in the recursive hot loop).

## Performance

The recursive `predict` hot loop is sensitive to per-call narwhals overhead. The per-step feature null-check was restructured so it runs on raw numpy feature values before frame assembly, statics are scanned once per `predict` in `_predict_setup`, and `X_df` is pre-scanned once — restoring the hot-loop cost to parity with `main` (local A/B: ~78 ms → ~30 ms).

## Testing

- `pre-commit` (ruff + mypy) passes on all changed files.
- CodSpeed benchmarks (`tests/test_pipeline.py::test_predict`, `test_preprocess`) back to base parity.
