### PR TITLE
[FEAT] Add `history_warmup` to build the forecasting state without materializing features

### DIFF
--- a/docs/core.html.md
+++ b/docs/core.html.md
@@ -78,6 +78,7 @@ serie
       docstring_style: google
       members:
         - fit_transform
+        - history_warmup
         - predict
         - update
       heading_level: 3

--- a/docs/forecast.html.md
+++ b/docs/forecast.html.md
@@ -19,6 +19,7 @@ title: MLForecast
         - get_missing_future
         - predict
         - preprocess
+        - history_warmup
         - fit_models
         - cross_validation
         - cv

--- a/mlforecast/core.py
+++ b/mlforecast/core.py
@@ -1242,6 +1242,7 @@ class TimeSeries:
         weight_col: Optional[str] = None,
         max_horizon: Optional[int] = None,
         horizons: Optional[List[int]] = None,
+        as_numpy: Optional[bool] = None,
         trim: bool = True,
     ) -> "TimeSeries":
         """Build all internal state from `df` without materializing features.
@@ -1266,6 +1267,9 @@ class TimeSeries:
                 from a previous fit on this instance is preserved.
             horizons: Specific 1-indexed horizons the models were trained for.
                 Mutually exclusive with max_horizon.
+            as_numpy: Whether prediction passes a numpy array to the model
+                instead of a dataframe. When None, any value from a previous
+                fit is preserved (False for a fresh instance).
             trim: Apply the `keep_last_n` trim after warming the transform
                 state. `predict(new_df=...)` disables this to keep the full
                 provided history.
@@ -1294,7 +1298,10 @@ class TimeSeries:
             # unpickled instance being re-warmed); default to recursive mode
             self._horizons = getattr(self, "_horizons", None)
             self.max_horizon = getattr(self, "max_horizon", None)
-        self.as_numpy = getattr(self, "as_numpy", False)
+        if as_numpy is not None:
+            self.as_numpy = as_numpy
+        else:
+            self.as_numpy = getattr(self, "as_numpy", False)
         return self
 
     def _update_y(self, new: np.ndarray) -> None:

--- a/mlforecast/core.py
+++ b/mlforecast/core.py
@@ -260,6 +260,12 @@ class TimeSeries:
     _uniform_dates: bool = False
     _feature_null_cols: List[str]
     _xdf_null_cols: Optional[List[str]]
+    # Fit-time state (set in ``_fit``/``_apply_keep_last_n``). Declared here
+    # so mypy has a type regardless of method processing order.
+    keep_last_n: Optional[int]
+    last_dates: Any
+    static_features_: DataFrame
+    features_order_: List[str]
 
     def __init__(
         self,
@@ -395,15 +401,39 @@ class TimeSeries:
             w_state = max(tfm.update_samples for tfm in tfm_list)
             state.trim_to_last(max(self.keep_last_n, w_state))
 
+    def _apply_keep_last_n(self) -> None:
+        """Resolve ``keep_last_n`` and trim the stored history accordingly.
+
+        Infers ``keep_last_n`` from the transforms when the user didn't set it
+        and every transform supports updates, then slices the per-series arrays
+        and trims the pooled states (finite-window states only). Must run after
+        the lag transforms have computed their state, since local stateful
+        transforms (Expanding*/EWM) warm their buffers from the full history.
+        """
+        update_samples = [
+            getattr(tfm, "update_samples", -1) for tfm in self.transforms.values()
+        ]
+        if (
+            self.keep_last_n is None
+            and update_samples
+            and all(samples > 0 for samples in update_samples)
+        ):
+            # user didn't set keep_last_n and we can infer it from the transforms
+            self.keep_last_n = max(update_samples)
+        if self.keep_last_n is not None:
+            self.ga = self.ga.take_from_groups(slice(-self.keep_last_n, None))
+            self._trim_pooled_states()
+
     def _initialize_lag_transform_states(self) -> None:
         """Materialize lag transform state for subsequent update-based prediction.
 
         This is needed when a new ``TimeSeries`` instance is created from historical
-        data right before calling ``predict(new_df=...)``. Local (coreforecast)
-        transforms need a full ``transform`` pass so stateful transforms like
-        ``ExpandingMean`` can initialize their internal buffers before the first
-        ``update(...)`` call. Pooled transforms keep their state in ``_ts_aggs``
-        (built at construction), so they need no warm-up pass.
+        data without running the feature-materialization pass (``history_warmup``
+        or ``predict(new_df=...)``). Local (coreforecast) transforms need a full
+        ``transform`` pass so stateful transforms like ``ExpandingMean`` can
+        initialize their internal buffers before the first ``update(...)`` call.
+        Pooled transforms keep their state in ``_ts_aggs`` (built at
+        construction), so they need no warm-up pass.
         """
         core_tfms = self._get_core_lag_tfms()
         if core_tfms:
@@ -944,19 +974,7 @@ class TimeSeries:
             df = ufp.copy_if_pandas(df, deep=False)
 
         # once we've computed the features and target we can slice the series
-        update_samples = [
-            getattr(tfm, "update_samples", -1) for tfm in self.transforms.values()
-        ]
-        if (
-            self.keep_last_n is None
-            and update_samples
-            and all(samples > 0 for samples in update_samples)
-        ):
-            # user didn't set keep_last_n and we can infer it from the transforms
-            self.keep_last_n = max(update_samples)
-        if self.keep_last_n is not None:
-            self.ga = self.ga.take_from_groups(slice(-self.keep_last_n, None))
-            self._trim_pooled_states()
+        self._apply_keep_last_n()
         del self._restore_idxs, self._sort_idxs
 
         # lag transforms
@@ -1212,6 +1230,72 @@ class TimeSeries:
             return_X_y=return_X_y,
             as_numpy=as_numpy,
         )
+
+    def history_warmup(
+        self,
+        df: DataFrame,
+        id_col: str,
+        time_col: str,
+        target_col: str,
+        static_features: Optional[List[str]] = None,
+        keep_last_n: Optional[int] = None,
+        weight_col: Optional[str] = None,
+        max_horizon: Optional[int] = None,
+        horizons: Optional[List[int]] = None,
+        trim: bool = True,
+    ) -> "TimeSeries":
+        """Build all internal state from `df` without materializing features.
+
+        Runs the same state-building steps as `fit_transform` (series storage,
+        target transforms, lag-transform buffers, pooled states, feature order)
+        but skips computing and assembling the features dataframe. After this
+        the instance supports `update` and `predict`, e.g. to warm a loaded
+        instance from raw history before updating it with new observations.
+
+        Args:
+            df: Series data in long format.
+            id_col: Column that identifies each serie.
+            time_col: Column that identifies each timestep.
+            target_col: Column that contains the target.
+            static_features: Names of the features that are static.
+            keep_last_n: Keep only these many records from each serie. When
+                None it's inferred from the transforms, like in `fit_transform`.
+            weight_col: Column that contains the sample weights.
+            max_horizon: Horizon the models were trained for (one model per
+                horizon). Leave None for recursive models; when None, any value
+                from a previous fit on this instance is preserved.
+            horizons: Specific 1-indexed horizons the models were trained for.
+                Mutually exclusive with max_horizon.
+            trim: Apply the `keep_last_n` trim after warming the transform
+                state. `predict(new_df=...)` disables this to keep the full
+                provided history.
+        """
+        self._fit(
+            df=df,
+            id_col=id_col,
+            time_col=time_col,
+            target_col=target_col,
+            static_features=static_features,
+            keep_last_n=keep_last_n,
+            weight_col=weight_col,
+        )
+        # must run before trimming: local stateful transforms (Expanding*/EWM)
+        # warm their buffers from the full history
+        self._initialize_lag_transform_states()
+        if trim:
+            self._apply_keep_last_n()
+        del self._restore_idxs, self._sort_idxs
+        if max_horizon is not None or horizons is not None:
+            self._horizons, self.max_horizon = _validate_horizon_params(
+                max_horizon, horizons
+            )
+        else:
+            # preserve model-shape metadata from a previous fit (e.g. an
+            # unpickled instance being re-warmed); default to recursive mode
+            self._horizons = getattr(self, "_horizons", None)
+            self.max_horizon = getattr(self, "max_horizon", None)
+        self.as_numpy = getattr(self, "as_numpy", False)
+        return self
 
     def _update_y(self, new: np.ndarray) -> None:
         """Appends the elements of `new` to every time serie.

--- a/mlforecast/forecast.py
+++ b/mlforecast/forecast.py
@@ -561,6 +561,32 @@ class MLForecast:
                 horizon_feature_templates=horizon_feature_templates,
                 weight_col=weight_col,
             )
+        elif self.ts.horizon_features_:
+            # Preserving the mapping from a previous fit (the explicit branch
+            # above re-validates it). `_fit` rebuilds `features_order_` from
+            # `df.columns`, so a preserved mapping referencing exog columns
+            # absent from `df` would otherwise surface as a raw ``KeyError``
+            # deep inside ``predict``. Validate it eagerly here instead.
+            exog_cols = set(
+                self._get_dynamic_exog_cols(
+                    list(df.columns),
+                    id_col=id_col,
+                    time_col=time_col,
+                    target_col=target_col,
+                    static_features=static_features,
+                    weight_col=weight_col,
+                )
+            )
+            missing = {
+                col for cols in self.ts.horizon_features_.values() for col in cols
+            } - exog_cols
+            if missing:
+                raise ValueError(
+                    "Preserved `horizon_features` reference columns missing from "
+                    f"the warmup data's dynamic exogenous features: {sorted(missing)}. "
+                    "Pass `horizon_features` explicitly to reconfigure the model "
+                    "shape, or include the columns in `df`."
+                )
         if not hasattr(self, "_cs_df"):
             self._cs_df = None
         if not hasattr(self, "_cs_source_scales_"):

--- a/mlforecast/forecast.py
+++ b/mlforecast/forecast.py
@@ -238,6 +238,33 @@ class MLForecast:
     ) -> None:
         validate_df(df, id_col, time_col, self.freq)
 
+    def _validate_data_or_warn(
+        self,
+        df: DataFrame,
+        id_col: str,
+        time_col: str,
+        validate_data: bool,
+    ) -> None:
+        if validate_data:
+            self._validate_data(df, id_col, time_col)
+        else:
+            has_pooled = any(
+                getattr(v, "global_", False)
+                or getattr(v, "groupby", None)
+                or getattr(v, "partition_by", None)
+                for v in self.ts.transforms.values()
+            )
+            if has_pooled:
+                warnings.warn(
+                    "Pooled (global/groupby/partition_by) lag transforms assume "
+                    "a continuous, gap-free time grid. Data validation has been "
+                    "disabled (validate_data=False), so timestamp gaps may "
+                    "silently produce incorrect feature values. Consider "
+                    "enabling validation or pre-validating your data.",
+                    UserWarning,
+                    stacklevel=3,
+                )
+
     def _get_dynamic_exog_cols(
         self,
         df_columns: List[str],
@@ -432,25 +459,7 @@ class MLForecast:
             DataFrame or tuple of pandas Dataframe and a numpy array: `df` plus added features and target(s).
         """
         # Run data validations if requested
-        if validate_data:
-            self._validate_data(df, id_col, time_col)
-        else:
-            has_pooled = any(
-                getattr(v, "global_", False)
-                or getattr(v, "groupby", None)
-                or getattr(v, "partition_by", None)
-                for v in self.ts.transforms.values()
-            )
-            if has_pooled:
-                warnings.warn(
-                    "Pooled (global/groupby/partition_by) lag transforms assume "
-                    "a continuous, gap-free time grid. Data validation has been "
-                    "disabled (validate_data=False), so timestamp gaps may "
-                    "silently produce incorrect feature values. Consider "
-                    "enabling validation or pre-validating your data.",
-                    UserWarning,
-                    stacklevel=2,
-                )
+        self._validate_data_or_warn(df, id_col, time_col, validate_data)
         self.ts.horizon_features_ = self._resolve_horizon_features(
             df=df,
             id_col=id_col,
@@ -478,6 +487,80 @@ class MLForecast:
             as_numpy=as_numpy,
             weight_col=weight_col,
         )
+
+    def history_warmup(
+        self,
+        df: DFType,
+        id_col: str = "unique_id",
+        time_col: str = "ds",
+        target_col: str = "y",
+        static_features: Optional[List[str]] = None,
+        keep_last_n: Optional[int] = None,
+        weight_col: Optional[str] = None,
+        max_horizon: Optional[int] = None,
+        horizons: Optional[List[int]] = None,
+        horizon_features: Optional[Dict[int, List[str]]] = None,
+        horizon_feature_templates: Optional[List[str]] = None,
+        validate_data: bool = True,
+    ) -> "MLForecast":
+        """Build the internal state from `df` without computing the features.
+
+        Runs the same state-building steps as `preprocess` (series storage,
+        target transforms, lag-transform buffers, pooled aggregates, feature
+        order) but skips materializing the features dataframe, which makes it
+        much cheaper when the features themselves aren't needed. Use it to warm
+        an instance whose models are already trained -- e.g. after unpickling,
+        `MLForecast.load`, or assigning externally trained models to `models_`
+        -- so that `update` and `predict` can be used without calling `fit` or
+        `preprocess` first.
+
+        History is trimmed like in `fit`: `keep_last_n` (explicit or inferred
+        from the transforms) is applied after the transform states are warmed,
+        so only the observations required for updates are kept.
+
+        Args:
+            df (pandas or polars DataFrame): Series data in long format.
+            id_col (str): Column that identifies each serie. Defaults to 'unique_id'.
+            time_col (str): Column that identifies each timestep, its values can be timestamps or integers. Defaults to 'ds'.
+            target_col (str): Column that contains the target. Defaults to 'y'.
+            static_features (list of str, optional): Names of the features that are static and will be repeated when forecasting. Defaults to None.
+            keep_last_n (int, optional): Keep only these many records from each serie for the forecasting step. Inferred from the transforms when None. Defaults to None.
+            weight_col (str, optional): Column that contains the sample weights. Defaults to None.
+            max_horizon (int, optional): Horizon the models were trained for when using one model per horizon. Leave None for recursive models; when None, any value from a previous fit is preserved. Defaults to None.
+            horizons (list of int, optional): Specific 1-indexed horizons the models were trained for. Mutually exclusive with max_horizon. Defaults to None.
+            horizon_features (dict of int to list of str, optional): Explicit mapping of 1-indexed horizons to dynamic exogenous columns the models were trained with. When None, any mapping from a previous fit is preserved. Defaults to None.
+            horizon_feature_templates (list of str, optional): Template patterns for horizon-specific dynamic exogenous features, e.g. ['feature_h{h}']. Defaults to None.
+            validate_data (bool): Run data quality validations before warming up. Warns about missing dates and raises on duplicate rows. Defaults to True.
+
+        Returns:
+            MLForecast: Forecast object with the internal state built from `df`.
+        """
+        self._validate_data_or_warn(df, id_col, time_col, validate_data)
+        if horizon_features is not None or horizon_feature_templates is not None:
+            self.ts.horizon_features_ = self._resolve_horizon_features(
+                df=df,
+                id_col=id_col,
+                time_col=time_col,
+                target_col=target_col,
+                static_features=static_features,
+                max_horizon=max_horizon,
+                horizons=horizons,
+                horizon_features=horizon_features,
+                horizon_feature_templates=horizon_feature_templates,
+                weight_col=weight_col,
+            )
+        self.ts.history_warmup(
+            df,
+            id_col=id_col,
+            time_col=time_col,
+            target_col=target_col,
+            static_features=static_features,
+            keep_last_n=keep_last_n,
+            weight_col=weight_col,
+            max_horizon=max_horizon,
+            horizons=horizons,
+        )
+        return self
 
     def fit_models(
         self,
@@ -1403,8 +1486,11 @@ class MLForecast:
                 drop_auxiliary_columns=self.ts.drop_auxiliary_columns,
             )
             # Builds `_pooled_states` (global/groupby/partition_by), whose
-            # `_ts_aggs` are computed from the full `new_df` history here.
-            new_ts._fit(
+            # `_ts_aggs` are computed from the full `new_df` history, and warms
+            # up local (coreforecast) lag-transform buffers before the first
+            # update-based prediction step. trim=False keeps the full provided
+            # history rather than applying the `keep_last_n` trim.
+            new_ts.history_warmup(
                 new_df,
                 id_col=self.ts.id_col,
                 time_col=self.ts.time_col,
@@ -1412,10 +1498,8 @@ class MLForecast:
                 static_features=self.ts.static_features,
                 keep_last_n=self.ts.keep_last_n,
                 weight_col=self.ts.weight_col,
+                trim=False,
             )
-            # Warms up local (coreforecast) lag-transform buffers before the
-            # first update-based prediction step.
-            new_ts._initialize_lag_transform_states()
             new_ts.max_horizon = self.ts.max_horizon
             new_ts._horizons = self.ts._horizons
             new_ts.as_numpy = self.ts.as_numpy

--- a/mlforecast/forecast.py
+++ b/mlforecast/forecast.py
@@ -150,6 +150,11 @@ def _frozen_backtest(
 
 
 class MLForecast:
+    # Calibration state (set in ``fit``/``history_warmup``/``load``). Declared
+    # here so mypy has a type regardless of method processing order.
+    _cs_df: Optional[DataFrame]
+    _cs_source_scales_: Optional[Dict]
+
     def __init__(
         self,
         models: Models,
@@ -501,6 +506,7 @@ class MLForecast:
         horizons: Optional[List[int]] = None,
         horizon_features: Optional[Dict[int, List[str]]] = None,
         horizon_feature_templates: Optional[List[str]] = None,
+        as_numpy: Optional[bool] = None,
         validate_data: bool = True,
     ) -> "MLForecast":
         """Build the internal state from `df` without computing the features.
@@ -530,6 +536,7 @@ class MLForecast:
             horizons (list of int, optional): Specific 1-indexed horizons the models were trained for. Mutually exclusive with max_horizon. Defaults to None.
             horizon_features (dict of int to list of str, optional): Explicit mapping of 1-indexed horizons to dynamic exogenous columns the models were trained with. When None, any mapping from a previous fit is preserved. Defaults to None.
             horizon_feature_templates (list of str, optional): Template patterns for horizon-specific dynamic exogenous features, e.g. ['feature_h{h}']. Defaults to None.
+            as_numpy (bool, optional): Whether prediction passes a numpy array to the model instead of a dataframe. When None, any value from a previous fit is preserved (False for a fresh instance). Defaults to None.
             validate_data (bool): Run data quality validations before warming up. Warns about missing dates and raises on duplicate rows. Defaults to True.
 
         Returns:
@@ -537,18 +544,27 @@ class MLForecast:
         """
         self._validate_data_or_warn(df, id_col, time_col, validate_data)
         if horizon_features is not None or horizon_feature_templates is not None:
+            effective_max_horizon = max_horizon
+            if effective_max_horizon is None and horizons is None:
+                # preserve model-shape metadata from a previous fit (e.g. an
+                # unpickled instance being re-warmed), same as TimeSeries.history_warmup
+                effective_max_horizon = getattr(self.ts, "max_horizon", None)
             self.ts.horizon_features_ = self._resolve_horizon_features(
                 df=df,
                 id_col=id_col,
                 time_col=time_col,
                 target_col=target_col,
                 static_features=static_features,
-                max_horizon=max_horizon,
+                max_horizon=effective_max_horizon,
                 horizons=horizons,
                 horizon_features=horizon_features,
                 horizon_feature_templates=horizon_feature_templates,
                 weight_col=weight_col,
             )
+        if not hasattr(self, "_cs_df"):
+            self._cs_df = None
+        if not hasattr(self, "_cs_source_scales_"):
+            self._cs_source_scales_ = None
         self.ts.history_warmup(
             df,
             id_col=id_col,
@@ -559,6 +575,7 @@ class MLForecast:
             weight_col=weight_col,
             max_horizon=max_horizon,
             horizons=horizons,
+            as_numpy=as_numpy,
         )
         return self
 
@@ -1132,8 +1149,8 @@ class MLForecast:
             for tfm in self.ts.target_transforms:
                 if hasattr(tfm, "store_fitted"):
                     tfm.store_fitted = True
-        self._cs_df: Optional[DataFrame] = None
-        self._cs_source_scales_: Optional[Dict] = None
+        self._cs_df = None
+        self._cs_source_scales_ = None
         if prediction_intervals is not None:
             self.prediction_intervals = prediction_intervals
             self._cs_df = self._conformity_scores(

--- a/nbs/docs/how-to-guides/custom_training.ipynb
+++ b/nbs/docs/how-to-guides/custom_training.ipynb
@@ -475,6 +475,143 @@
    "source": [
     "fcst.predict(1)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1f3c9d2-5b6e-4f7a-8c0d-1e2f3a4b5c6d",
+   "metadata": {},
+   "source": [
+    "## Skipping preprocess: warming up from history\n",
+    "\n",
+    "The flow above ran `MLForecast.preprocess` because we needed the training features. If your models are already trained -- for example you just unpickled them in a serving process, or trained them yourself like above -- computing the features again just to restore the internal state would be wasted work. `MLForecast.history_warmup` is a cheaper alternative for that case: it runs the same state-building steps as `preprocess` (target transforms, lag transform buffers, pooled aggregates, feature order) but skips materializing the features dataframe. Like `fit`, it also keeps only the history required for the updates (`keep_last_n`, explicit or inferred from the transforms)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b2e4d0a3-6c7f-4a8b-9d1e-2f3a4b5c6d7e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MLForecast(models=[], freq=D, lag_features=['lag1'], date_features=['dayofweek'], num_threads=1)"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fcst2 = MLForecast(\n",
+    "    models=[],\n",
+    "    freq='D',\n",
+    "    lags=[1],\n",
+    "    date_features=['dayofweek'],\n",
+    ")\n",
+    "fcst2.models_ = fcst.models_  # previously trained models\n",
+    "fcst2.history_warmup(series)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3f5e1b4-7d80-4b9c-a02f-3a4b5c6d7e8f",
+   "metadata": {},
+   "source": [
+    "After warming up, `MLForecast.update` and `MLForecast.predict` can be used directly -- without ever calling `fit` or `preprocess` -- and produce the same forecasts as before."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d4a6f2c5-8e91-4cad-b130-4b5c6d7e8f90",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>unique_id</th>\n",
+       "      <th>ds</th>\n",
+       "      <th>lr</th>\n",
+       "      <th>lgbm</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>id_0</td>\n",
+       "      <td>2000-08-10</td>\n",
+       "      <td>3.549124</td>\n",
+       "      <td>5.166797</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>id_1</td>\n",
+       "      <td>2000-04-07</td>\n",
+       "      <td>3.154285</td>\n",
+       "      <td>4.252490</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>id_2</td>\n",
+       "      <td>2000-06-16</td>\n",
+       "      <td>2.880933</td>\n",
+       "      <td>3.224506</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>id_3</td>\n",
+       "      <td>2000-08-30</td>\n",
+       "      <td>4.061801</td>\n",
+       "      <td>0.245443</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>id_4</td>\n",
+       "      <td>2001-01-08</td>\n",
+       "      <td>2.904872</td>\n",
+       "      <td>2.225106</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  unique_id         ds        lr      lgbm\n",
+       "0      id_0 2000-08-10  3.549124  5.166797\n",
+       "1      id_1 2000-04-07  3.154285  4.252490\n",
+       "2      id_2 2000-06-16  2.880933  3.224506\n",
+       "3      id_3 2000-08-30  4.061801  0.245443\n",
+       "4      id_4 2001-01-08  2.904872  2.225106"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fcst2.predict(1)"
+   ]
   }
  ],
  "metadata": {

--- a/tests/test_history_warmup.py
+++ b/tests/test_history_warmup.py
@@ -1,4 +1,6 @@
 import datetime
+import tempfile
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -7,6 +9,7 @@ import pytest
 from sklearn.linear_model import LinearRegression
 
 from mlforecast import MLForecast
+from mlforecast.conformal_prediction import PredictionIntervals
 from mlforecast.lag_transforms import (
     ExpandingMean,
     ExponentiallyWeightedMean,
@@ -206,6 +209,89 @@ def test_history_warmup_requires_models_for_predict():
     fcst.history_warmup(_gen("pandas"))
     with pytest.raises(ValueError, match="No fitted models"):
         fcst.predict(H)
+
+
+def test_history_warmup_preserves_horizon_features_shape():
+    """Re-warming an already-fitted instance with `horizon_features` but no
+    explicit `max_horizon`/`horizons` must resolve against the preserved
+    shape instead of raising ("only supported when using max_horizon or
+    horizons")."""
+    df = _gen("pandas")[["unique_id", "ds", "y"]]
+    df["exog_h1"] = df["y"] * 0.9
+    df["exog_h2"] = df["y"] * 0.7
+    horizon_features = {1: ["exog_h1"], 2: ["exog_h2"]}
+
+    fcst = MLForecast(models=[LinearRegression()], freq="D", lags=[1])
+    fcst.fit(
+        df.copy(),
+        static_features=[],
+        max_horizon=H,
+        horizon_features=horizon_features,
+    )
+    expected = fcst.horizon_features_
+
+    fcst.history_warmup(
+        df.copy(), static_features=[], horizon_features=horizon_features
+    )
+    assert fcst.horizon_features_ == expected
+    assert fcst.ts.max_horizon == H
+
+
+def test_history_warmup_calibration_state_defaults():
+    """A fresh instance with externally supplied models has no calibration
+    state until warmed. `predict(level=...)` should warn like an
+    un-configured `fit` does (not raise `AttributeError`), and `save()`
+    should omit the interval artifact instead of crashing. Re-warming an
+    already-calibrated instance must leave its state untouched."""
+    df = _gen("pandas")[["unique_id", "ds", "y"]]
+
+    source = _new_fcst("local")
+    source.fit(df.copy())
+
+    warmed = _new_fcst("local")
+    warmed.models_ = source.models_
+    warmed.history_warmup(df.copy())
+
+    with pytest.warns(UserWarning, match="prediction intervals"):
+        warmed.predict(H, level=[90])
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        savedir = Path(tmpdir) / "fcst"
+        savedir.mkdir()
+        warmed.save(savedir)  # must not raise despite no calibration state
+
+    calibrated = _new_fcst("local")
+    calibrated.fit(df.copy(), prediction_intervals=PredictionIntervals(n_windows=2))
+    cs_df_before = calibrated._cs_df
+    calibrated.history_warmup(df.copy())
+    assert calibrated._cs_df is cs_df_before
+
+
+def test_history_warmup_as_numpy():
+    """A fresh instance can opt into numpy model input via `as_numpy`; when
+    omitted, re-warming an already-configured instance keeps its existing
+    setting."""
+
+    class RecordingModel(LinearRegression):
+        last_X_type = None
+
+        def predict(self, X):
+            RecordingModel.last_X_type = type(X)
+            return super().predict(np.asarray(X))
+
+    df = _gen("pandas")[["unique_id", "ds", "y"]]
+
+    source = MLForecast(models=[RecordingModel()], freq="D", lags=[1])
+    source.fit(df.copy(), as_numpy=True)
+
+    fresh = MLForecast(models=[RecordingModel()], freq="D", lags=[1])
+    fresh.models_ = source.models_
+    fresh.history_warmup(df.copy(), as_numpy=True)
+    fresh.predict(H)
+    assert RecordingModel.last_X_type is np.ndarray
+
+    source.history_warmup(df.copy())
+    assert source.ts.as_numpy is True
 
 
 def test_history_warmup_validation():

--- a/tests/test_history_warmup.py
+++ b/tests/test_history_warmup.py
@@ -1,0 +1,220 @@
+import datetime
+
+import numpy as np
+import pandas as pd
+import polars as pl
+import pytest
+from sklearn.linear_model import LinearRegression
+
+from mlforecast import MLForecast
+from mlforecast.lag_transforms import (
+    ExpandingMean,
+    ExponentiallyWeightedMean,
+    RollingMean,
+)
+from mlforecast.target_transforms import Differences, LocalStandardScaler
+from mlforecast.utils import generate_daily_series
+
+H = 4
+
+
+def _gen(engine, n_static_features=0):
+    return generate_daily_series(
+        10,
+        min_length=60,
+        max_length=80,
+        equal_ends=True,
+        n_static_features=n_static_features,
+        static_as_categorical=False,
+        engine=engine,
+    )
+
+
+def _split_last(df, engine, days):
+    if engine == "polars":
+        cutoff = df["ds"].max() - datetime.timedelta(days=days)
+        return df.filter(pl.col("ds") <= cutoff), df.filter(pl.col("ds") > cutoff)
+    cutoff = df["ds"].max() - datetime.timedelta(days=days)
+    return df[df["ds"] <= cutoff], df[df["ds"] > cutoff]
+
+
+def _config(kind, engine="pandas"):
+    if kind == "local":
+        return dict(
+            lags=[1, 7],
+            lag_transforms={
+                1: [
+                    RollingMean(7),
+                    ExpandingMean(),
+                    ExponentiallyWeightedMean(alpha=0.5),
+                ]
+            },
+        )
+    if kind == "pooled":
+        return dict(
+            lags=[1, 7],
+            lag_transforms={
+                1: [
+                    RollingMean(7),
+                    RollingMean(7, global_=True),
+                    RollingMean(7, groupby=["static_0"]),
+                    ExpandingMean(global_=True),
+                ]
+            },
+        )
+    assert kind == "target_tfms"
+    return dict(
+        lags=[1, 7],
+        lag_transforms={1: [RollingMean(7), ExpandingMean()]},
+        target_transforms=[Differences([1]), LocalStandardScaler()],
+        date_features=["weekday" if engine == "polars" else "dayofweek"],
+    )
+
+
+def _new_fcst(kind, engine="pandas"):
+    freq = "1d" if engine == "polars" else "D"
+    return MLForecast(models=[LinearRegression()], freq=freq, **_config(kind, engine))
+
+
+def _assert_preds_equal(p1, p2):
+    np.testing.assert_allclose(
+        np.asarray(p1["LinearRegression"]),
+        np.asarray(p2["LinearRegression"]),
+        rtol=1e-9,
+        atol=1e-9,
+    )
+
+
+@pytest.mark.parametrize("engine", ["pandas", "polars"])
+@pytest.mark.parametrize("kind", ["local", "pooled", "target_tfms"])
+def test_history_warmup_predict_parity(engine, kind):
+    n_statics = 1 if kind == "pooled" else 0
+    fitted = _new_fcst(kind, engine)
+    fitted.fit(_gen(engine, n_statics))
+    expected = fitted.predict(H)
+
+    warmed = _new_fcst(kind, engine)
+    warmed.models_ = fitted.models_
+    assert warmed.history_warmup(_gen(engine, n_statics)) is warmed
+    _assert_preds_equal(expected, warmed.predict(H))
+
+
+@pytest.mark.parametrize("engine", ["pandas", "polars"])
+@pytest.mark.parametrize("kind", ["local", "pooled", "target_tfms"])
+def test_history_warmup_update_predict_parity(engine, kind):
+    n_statics = 1 if kind == "pooled" else 0
+    train, tail = _split_last(_gen(engine, n_statics), engine, days=3)
+
+    fitted = _new_fcst(kind, engine)
+    fitted.fit(train)
+    fitted.update(tail)
+    expected = fitted.predict(H)
+
+    train, tail = _split_last(_gen(engine, n_statics), engine, days=3)
+    warmed = _new_fcst(kind, engine)
+    warmed.models_ = fitted.models_
+    warmed.history_warmup(train)
+    warmed.update(tail)
+    _assert_preds_equal(expected, warmed.predict(H))
+
+
+def test_history_warmup_partition_by():
+    series = _gen("pandas")
+    # alternate promo daily so every 3-wide window has samples in both buckets
+    series["promo"] = series["ds"].dt.dayofweek % 2
+
+    def new_fcst():
+        return MLForecast(
+            models=[LinearRegression()],
+            freq="D",
+            lags=[1],
+            lag_transforms={1: [RollingMean(3, partition_by=["promo"])]},
+        )
+
+    fitted = new_fcst()
+    fitted.fit(series.copy(), static_features=[])
+    last = series["ds"].max()
+    x_df = series[series["ds"] > last - datetime.timedelta(days=H)][
+        ["unique_id", "ds"]
+    ].copy()
+    x_df["ds"] += datetime.timedelta(days=H)
+    x_df["promo"] = x_df["ds"].dt.dayofweek % 2
+    expected = fitted.predict(H, X_df=x_df)
+
+    warmed = new_fcst()
+    warmed.models_ = fitted.models_
+    warmed.history_warmup(series.copy(), static_features=[])
+    _assert_preds_equal(expected, warmed.predict(H, X_df=x_df))
+
+
+def test_history_warmup_trims_like_fit():
+    fitted = _new_fcst("pooled")
+    fitted.fit(_gen("pandas", 1))
+
+    warmed = _new_fcst("pooled")
+    warmed.history_warmup(_gen("pandas", 1))
+
+    # keep_last_n inferred like in fit and per-series arrays trimmed to it
+    assert warmed.ts.keep_last_n == fitted.ts.keep_last_n
+    np.testing.assert_array_equal(warmed.ts.ga.indptr, fitted.ts.ga.indptr)
+    # pooled states trimmed the same way (finite-window ones trim, the state
+    # containing ExpandingMean keeps full history)
+    for key, state in warmed.ts._pooled_states.items():
+        fitted_state = fitted.ts._pooled_states[key]
+        np.testing.assert_array_equal(state.time_index, fitted_state.time_index)
+
+    explicit = _new_fcst("local")
+    explicit.history_warmup(_gen("pandas"), keep_last_n=30)
+    assert explicit.ts.keep_last_n == 30
+    assert np.diff(explicit.ts.ga.indptr).max() == 30
+
+
+def test_history_warmup_multioutput_models():
+    series = _gen("pandas")[["unique_id", "ds", "y"]]
+
+    fitted = MLForecast(models=[LinearRegression()], freq="D", lags=[1, 7])
+    fitted.fit(series.copy(), max_horizon=H)
+    expected = fitted.predict(H)
+
+    warmed = MLForecast(models=[LinearRegression()], freq="D", lags=[1, 7])
+    warmed.models_ = fitted.models_
+    warmed.history_warmup(series.copy(), max_horizon=H)
+    _assert_preds_equal(expected, warmed.predict(H))
+
+    # without max_horizon the existing model-shape guard fires
+    unshaped = MLForecast(models=[LinearRegression()], freq="D", lags=[1, 7])
+    unshaped.models_ = fitted.models_
+    unshaped.history_warmup(series.copy())
+    with pytest.raises(ValueError, match="one model per horizon"):
+        unshaped.predict(H)
+
+
+def test_history_warmup_preserves_prototype_metadata():
+    """Re-warming an already fitted instance keeps its model-shape metadata."""
+    series = _gen("pandas")[["unique_id", "ds", "y"]]
+    fcst = MLForecast(models=[LinearRegression()], freq="D", lags=[1, 7])
+    fcst.fit(series.copy(), max_horizon=H)
+    expected = fcst.predict(H)
+
+    fcst.history_warmup(series.copy())
+    assert fcst.ts.max_horizon == H
+    _assert_preds_equal(expected, fcst.predict(H))
+
+
+def test_history_warmup_requires_models_for_predict():
+    fcst = _new_fcst("local")
+    fcst.history_warmup(_gen("pandas"))
+    with pytest.raises(ValueError, match="No fitted models"):
+        fcst.predict(H)
+
+
+def test_history_warmup_validation():
+    series = _gen("pandas")
+    duplicated = pd.concat([series, series.head(1)])
+    fcst = _new_fcst("local")
+    with pytest.raises(ValueError):
+        fcst.history_warmup(duplicated)
+
+    pooled = _new_fcst("pooled")
+    with pytest.warns(UserWarning, match="gap-free"):
+        pooled.history_warmup(_gen("pandas", 1), validate_data=False)

--- a/tests/test_history_warmup.py
+++ b/tests/test_history_warmup.py
@@ -237,6 +237,35 @@ def test_history_warmup_preserves_horizon_features_shape():
     assert fcst.ts.max_horizon == H
 
 
+def test_history_warmup_preserved_horizon_features_missing_cols():
+    """Re-warming a `horizon_features` instance without re-passing them
+    preserves the mapping (`_fit` rebuilds `features_order_` from the new
+    frame). If that frame drops the referenced exog columns the preserved
+    mapping is stale, and warming must raise a clear error instead of letting
+    a raw `KeyError` surface later inside `predict`."""
+    df = _gen("pandas")[["unique_id", "ds", "y"]]
+    df["exog_h1"] = df["y"] * 0.9
+    df["exog_h2"] = df["y"] * 0.7
+    horizon_features = {1: ["exog_h1"], 2: ["exog_h2"]}
+
+    fcst = MLForecast(models=[LinearRegression()], freq="D", lags=[1])
+    fcst.fit(
+        df.copy(),
+        static_features=[],
+        max_horizon=H,
+        horizon_features=horizon_features,
+    )
+
+    # re-warm with the exog columns dropped and without re-passing the mapping
+    without_exog = df[["unique_id", "ds", "y"]].copy()
+    with pytest.raises(ValueError, match="exog_h1.*exog_h2"):
+        fcst.history_warmup(without_exog, static_features=[])
+
+    # still fine when the columns are present (mapping stays valid)
+    fcst.history_warmup(df.copy(), static_features=[])
+    assert fcst.horizon_features_ == horizon_features
+
+
 def test_history_warmup_calibration_state_defaults():
     """A fresh instance with externally supplied models has no calibration
     state until warmed. `predict(level=...)` should warn like an


### PR DESCRIPTION
This PR adds `MLForecast.history_warmup()` (backed by `TimeSeries.history_warmup()`), which ingests raw history and builds all the internal state required for forecasting — series storage, target-transform state, local (coreforecast) lag-transform buffers, pooled aggregate states, and the feature order — without computing or assembling the training features dataframe. It is the cheap alternative to `preprocess` for the case where the models are already trained and the features would be thrown away.

## Motivation

Today the public ways to get a predict-ready object are `fit` and `preprocess` — both of which pay the full cost of materializing every lag transform into a wide features dataframe — or the transfer-learning path `predict(new_df=...)`, which builds state cheaply but only works on an already-fitted instance and is fused to producing a forecast (see the comparison below). In serving scenarios — unpickling trained models, `MLForecast.load`, or assigning externally trained estimators to `models_` — that work is pure overhead: the user only wants to load history, optionally `update()` with fresh observations, and `predict()`. This also composes with the recent `keep_last_n` trimming work (#679): after warming up, history is stripped down to what updates actually need, with the transform accumulators kept in its place.

```python
fcst = MLForecast(models=[], freq="D", lags=[1], date_features=["dayofweek"])
fcst.models_ = trained_models  # unpickled or trained elsewhere
fcst.history_warmup(history_df)
fcst.update(new_observations)  # optional
fcst.predict(7)
```

## Relationship to `predict(new_df=...)`

The transfer-learning path `predict(h, new_df=history, X_df=future_exog)` already built the forecasting state from raw history without materializing features, and even persists the new state on `self.ts` after a successful call — for a *previously fitted* object, a one-shot forecast from new history was already covered. `history_warmup` is that internal mechanism lifted into a public method (and `predict(new_df=)` now delegates to it), with the following explicit differences:

- **Works on never-fitted objects.** `predict(new_df=)` reads its configuration (`id_col`/`time_col`/`target_col`, `static_features`, `keep_last_n`, `weight_col`, `max_horizon`, `_horizons`, `as_numpy`) from `self.ts` attributes that only exist after a `fit`/`preprocess`, so a fresh `MLForecast` with externally assigned `models_` fails with `AttributeError: 'TimeSeries' object has no attribute 'max_horizon'`. `history_warmup` takes these as arguments, so "construct + assign `models_` + warm up" now works without ever running `preprocess`.
- **Decoupled from forecasting.** State-building is no longer fused to the first predict: you can warm at load time, `update()` repeatedly as observations arrive, and predict on demand — including update-first workflows where no forecast precedes the first update.
- **Memory.** `predict(new_df=)` keeps the full provided history (behavior preserved via `trim=False`); `history_warmup` applies the `keep_last_n` trim like `fit`, so long histories collapse to what updates actually need.
- **Validation.** `predict(new_df=)` runs no data-quality checks on the provided history; `history_warmup` has the same `validate_data` prelude as `preprocess` (gap/duplicate detection, pooled gap-free warning).
- **Model-shape metadata.** For one-model-per-horizon setups, `history_warmup(max_horizon=...)`/`horizons=...` declares how external models were trained; `predict(new_df=)` can only inherit that from a previous fit.

## What changed

- `TimeSeries.history_warmup(df, ..., max_horizon=None, horizons=None, trim=True)`: runs `_fit` (validation, ga/uids/last_dates, target-transform `fit_transform`, static features, `features_order_`, pooled states), warms the local lag-transform buffers via `_initialize_lag_transform_states()` (required so stateful transforms like `ExpandingMean`/`ExponentiallyWeightedMean` can serve `update`-based predictions), and then applies the `keep_last_n` trim for parity with `fit`.
- `MLForecast.history_warmup(...)`: public entry point with the same data-validation prelude as `preprocess` (`validate_data=True` runs the gap/duplicate checks; `validate_data=False` warns when pooled transforms are configured). `max_horizon`/`horizons` (and `horizon_features`/`horizon_feature_templates`) describe how the models were trained; when omitted, any metadata from a previous fit on the instance is preserved, so re-warming an unpickled fitted object just works.
- The `keep_last_n` inference+trim block was extracted from `_transform` into a shared `TimeSeries._apply_keep_last_n()` helper; `_transform` behavior is unchanged.
- The internal `predict(new_df=...)` warm path was refactored to reuse `history_warmup(..., trim=False)`, removing the duplicated `_fit` + warm-up + metadata sequence while keeping its full-history behavior byte-identical.
- mypy: added class-body attribute annotations on `TimeSeries` (`keep_last_n`, `last_dates`, `static_features_`, `features_order_`) since the extracted helper assigns `keep_last_n` textually before `_fit`, following the existing `_uniform_dates` precedent.

## Behavior notes

- Trimming matches `fit`: an explicit `keep_last_n` is honored, otherwise it is inferred from the transforms' `update_samples`; pooled states keep the finite-window-only trimming rules from #679.
- `predict` guards are unchanged and cover the new flow: missing `models_` raises the existing "No fitted models found" error, and the model-shape check catches a warmup without `max_horizon` for one-model-per-horizon setups.
- Calling `history_warmup` again (or after `fit`) rebuilds the state from scratch; models are untouched.

## Tests

New `tests/test_history_warmup.py` (18 tests): prediction parity between `history_warmup`+`predict` and `fit`+`predict`, and between `history_warmup`+`update`+`predict` and the fit-path equivalent, across pandas/polars and local, pooled (`global_`/`groupby`), and target-transform (+date features) configurations, plus a `partition_by` case with `X_df`; state-trimming parity with `fit` (inferred and explicit `keep_last_n`); multioutput model handling and its guard; prototype-metadata preservation; the no-models guard; and both data-validation modes. Full core/forecast/pooled suites pass unchanged.

## Docs

The custom training guide (`nbs/docs/how-to-guides/custom_training.ipynb`) gains a "Skipping preprocess: warming up from history" section showing the flow as an alternative to the `preprocess` route, with outputs matching the guide's earlier predictions exactly. `history_warmup` is also listed in the `MLForecast` and `TimeSeries` API references.