### PR TITLE
docs: fix broken documentation links

### DIFF
--- a/nbs/docs/tutorials/electricity_peak_forecasting.ipynb
+++ b/nbs/docs/tutorials/electricity_peak_forecasting.ipynb
@@ -242,7 +242,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `cross_validation` method allows the user to simulate multiple historic forecasts, greatly simplifying pipelines by replacing for loops with `fit` and `predict` methods. This method re-trains the model and forecast each window. See [this tutorial](https://nixtla.github.io/statsforecast/examples/getting_started_complete.html) for an animation of how the windows are defined. \n",
+    "The `cross_validation` method allows the user to simulate multiple historic forecasts, greatly simplifying pipelines by replacing for loops with `fit` and `predict` methods. This method re-trains the model and forecast each window. See [this tutorial](https://nixtlaverse.nixtla.io/statsforecast/docs/getting-started/getting_started_complete.html) for an animation of how the windows are defined. \n",
     "\n",
     "Use the `cross_validation` method to produce all the daily forecasts for September. To produce daily forecasts set the forecasting horizon `window_size` as 24. In this example we are simulating deploying the pipeline during September, so set the number of windows as 30 (one for each day). Finally, the step size between windows is 24 (equal to the `window_size`). This ensure to only produce one forecast per day.\n",
     "\n",


### PR DESCRIPTION
## What

Replaces the retired StatsForecast GitHub Pages link in the electricity peak forecasting tutorial with the current Nixtlaverse route.

## Why

The legacy destination returns 404 and prevents readers from opening the referenced cross validation tutorial.

## How

1. Preserve the tutorial wording.
2. Point the link at the current StatsForecast getting started page.

## Testing

1. Parsed the changed notebook as valid JSON.
2. Requested the replacement route directly and confirmed a successful response.
3. Confirmed the destination exists in the generated StatsForecast aggregate and reran the aggregate Mintlify checker without introducing any new findings.
4. Ran `git diff --check`, reviewed the complete diff, and scanned for secrets and unintended artifacts.

## Checklist

1. [x] Title follows conventional commit format.
2. [x] The PR is limited to one documentation link.
3. [x] The complete diff was reviewed.
4. [x] No secrets, credentials, or personal data were added.
