### PR TITLE
docs: fix lag transform guide links

### DIFF
--- a/docs/lag_transforms.html.md
+++ b/docs/lag_transforms.html.md
@@ -51,7 +51,7 @@ statistics **across multiple series at once**.
 
 For a worked walkthrough of all of the above, including the `Combine` /
 `Offset` combinators and how to plug in custom numba-based transforms, see
-the [Lag transformations](docs/how-to-guides/lag_transforms_guide.html)
+the [Lag transformations](./docs/how-to-guides/lag_transforms_guide.html)
 how-to guide.
 
 ## Pooled mode: `global_`, `groupby`, and `partition_by`
@@ -99,7 +99,7 @@ threshold: `RollingMean(window_size=1, min_samples=2, groupby=["brand"])`
 produces a non-null value only at timestamps where at least two series in the
 brand contribute observations.
 
-See the [Pooled lag transforms](docs/how-to-guides/pooled_lag_transforms.html)
+See the [Pooled lag transforms](./docs/how-to-guides/pooled_lag_transforms.html)
 how-to guide for end-to-end examples.
 
 ::: mlforecast.lag_transforms.RollingQuantile


### PR DESCRIPTION
## What

Correct two generated API page links to the lag transform guides.

## Why

Mintlify interprets the bare `docs/...` targets from the API page as site root paths. The leading `./` makes both links resolve relative to the MLForecast section.

## How

1. Update the lag transformations guide target.
2. Update the pooled lag transforms guide target.

## Testing

1. Confirmed both previous resolved targets are broken.
2. Confirmed both corrected destinations return HTTP 200 three times each and contain the relevant guide content.
3. Ran the native Mintlify broken link checker against a fresh aggregate three times. Every run reported zero targeted findings.
4. Inspected the complete diff, ran `git diff --check`, and scanned the diff for credentials.

## Checklist

* [x] Only the two broken targets changed.
* [x] Both corrected pages exist and match the link text.
* [x] No generated page content was otherwise modified.

