### PR TITLE
docs: fix language error

### DIFF
--- a/nbs/docs/tutorials/prediction_intervals_in_forecasting_models.ipynb
+++ b/nbs/docs/tutorials/prediction_intervals_in_forecasting_models.ipynb
@@ -209,7 +209,7 @@
    "source": [
     "## Conformal Prediction\n",
     "\n",
-    "Multi-quantile losses and statistical models can provide provide prediction intervals, but the problem is that these are uncalibrated, meaning that the actual frequency of observations falling within the interval does not align with the confidence level associated with it. For example, a calibrated 95% prediction interval should contain the true value 95% of the time in repeated sampling. An uncalibrated 95% prediction interval, on the other hand, might contain the true value only 80% of the time, or perhaps 99% of the time. In the first case, the interval is too narrow and underestimates the uncertainty, while in the second case, it is too wide and overestimates the uncertainty.\n",
+    "Multi-quantile losses and statistical models can provide prediction intervals, but the problem is that these are uncalibrated, meaning that the actual frequency of observations falling within the interval does not align with the confidence level associated with it. For example, a calibrated 95% prediction interval should contain the true value 95% of the time in repeated sampling. An uncalibrated 95% prediction interval, on the other hand, might contain the true value only 80% of the time, or perhaps 99% of the time. In the first case, the interval is too narrow and underestimates the uncertainty, while in the second case, it is too wide and overestimates the uncertainty.\n",
     "\n",
     "Statistical methods also assume normality. Here, we talk about another method called conformal prediction that doesn’t require any distributional assumptions.\n",
     "\n",


### PR DESCRIPTION
## What

Fixes a duplicated word in the conformal prediction tutorial.

## Why

The published tutorial currently says “provide provide prediction intervals.” This is an objective language error visible to readers.

## How

1. Remove the duplicated word from the notebook source.

## Testing

1. [x] Parsed the notebook as valid JSON.
2. [x] Reviewed the complete diff.
3. [x] Confirmed no credentials or generated artifacts are included.

## Checklist

1. [x] The title follows the conventional commit format.
2. [x] The pull request is focused on one concern.
3. [x] The complete diff was reviewed.
4. [x] No secrets, credentials, or personal data are included.
