### PR TITLE
fix: support Ray Arrow-backed datasets in LightGBM training

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -94,8 +94,4 @@ jobs:
       - name: Run pytest
         env:
           RAY_ENABLE_UV_RUN_RUNTIME_ENV: 0
-          # ray >=2.56 converts blocks to pandas with pd.ArrowDtype columns, which
-          # lightgbm rejects ("pandas dtypes must be int, float or bool"). Keep the
-          # pre-2.56 numpy dtypes until the ray models cast the features themselves.
-          RAY_DATA_ENABLE_ARROW_BACKED_PANDAS_CONVERSION: 0
         run: uv run pytest --reruns=2 --reruns-delay=2 --only-rerun="Socket recv error"

--- a/mlforecast/distributed/forecast.py
+++ b/mlforecast/distributed/forecast.py
@@ -432,16 +432,28 @@ class DistributedMLForecast:
                 raise NotImplementedError(
                     "Only spark and dask engines currently support sample weights."
                 )
-            prep_selected = prep.select_columns(
-                cols=features + [target_col]
-            ).materialize()
-            X = RayDMatrix(
-                prep_selected,
-                label=target_col,
+            data_context = prep.context
+            arrow_backed = getattr(
+                data_context, "enable_arrow_backed_pandas_conversion", None
             )
-            for name, model in self.models.items():
-                trained_model = clone(model).fit(X, y=None)
-                self.models_[name] = trained_model.model_
+            if arrow_backed is not None:
+                data_context.enable_arrow_backed_pandas_conversion = False
+            try:
+                prep_selected = prep.select_columns(
+                    cols=features + [target_col]
+                ).materialize()
+                X = RayDMatrix(
+                    prep_selected,
+                    label=target_col,
+                )
+                for name, model in self.models.items():
+                    trained_model = clone(model).fit(X, y=None)
+                    self.models_[name] = trained_model.model_
+            finally:
+                if arrow_backed is not None:
+                    data_context.enable_arrow_backed_pandas_conversion = (
+                        arrow_backed
+                    )
         else:
             raise NotImplementedError(
                 "Only spark, dask, and ray engines are supported."


### PR DESCRIPTION
Title: fix: support Ray Arrow-backed datasets in LightGBM training

## Summary

- Temporarily disable Arrow-backed pandas conversion on the preprocessed Ray Dataset while LightGBM-Ray materializes and trains from it.
- Restore the Dataset's original conversion setting even when training raises.
- Remove the CI environment workaround so the existing Ray LightGBM fit coverage runs under Ray's default configuration.

Closes #713

## Test evidence

- Passed a focused source-branch assertion covering successful Ray fitting and context restoration after success and failure.
- Passed workflow assertions confirming the Ray conversion override is absent.
- Passed `python3 -m py_compile mlforecast/distributed/forecast.py` and `git diff --check`.
- The full Ray test could not be run locally because the locked Ray 2.56.1 wheel was unavailable in the offline cache; CI's existing `tests/distributed_ray/test_ray_combine_transforms.py` exercises the real LightGBM-Ray fit without the workaround.

## Risks or notes for maintainers

- The Dataset context setting is temporarily shared with concurrent operations using that same context, but it is restored in `finally` after synchronous training.
- Ray versions that do not expose the setting keep their existing behavior.
- No placement-group cleanup or timeout hardening is included; those are separate from the dtype failure.
