### PR TITLE
chore: standardize PR titles and extend Dependabot to Python deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,10 @@ updates:
     groups:
       ci-dependencies:
         patterns: ["*"]
+  - package-ecosystem: "uv"
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      python-dependencies:
+        patterns: ["*"]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@ Please make sure to provide a meaningful description and let us know that you've
 <!-- What this PR does. If this work is related to a specific issue please reference it here. -->
 
 Checklist:
-- [ ] This PR has a meaningful title and a clear description.
+- [ ] This PR title follows the [Conventional Commits format](../CONTRIBUTING.md#pr-title-format) (e.g. `feat: ...`, `fix: ...`) and has a clear description.
 - [ ] The tests pass.
 - [ ] All linting tasks pass.
 - [ ] The notebooks are clean.

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -7,12 +7,35 @@ categories:
     label: 'breaking change'
   - title: 'Bug Fixes'
     label: 'fix'
+  - title: 'Performance'
+    label: 'performance'
   - title: 'Documentation'
     label: 'documentation'
+  - title: 'Maintenance'
+    label: 'chore'
   - title: 'Dependencies'
     label: 'dependencies'
   - title: 'Enhancement'
     label: 'enhancement'
+autolabeler:
+  - label: 'breaking change'
+    title:
+      - '/^\w+(\(.+\))?!:/'
+  - label: 'feature'
+    title:
+      - '/^feat(\(.+\))?:/'
+  - label: 'fix'
+    title:
+      - '/^fix(\(.+\))?:/'
+  - label: 'performance'
+    title:
+      - '/^perf(\(.+\))?:/'
+  - label: 'documentation'
+    title:
+      - '/^docs(\(.+\))?:/'
+  - label: 'chore'
+    title:
+      - '/^(chore|refactor|style|test|build|ci)(\(.+\))?:/'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 template: |
   ## Changes

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,25 @@
+name: Dependabot auto-merge
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch dependency metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch/minor bumps
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,32 @@
+name: PR Title Lint
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d5 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          requireScope: false
+          ignoreLabels: |
+            dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,6 +132,30 @@ Note: Ray tests are excluded from `uv run pytest` due to incompatibility between
 
 ## PR submission guidelines
 
+### PR title format
+
+PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/): `type(scope): subject`, where `scope` is optional. This is enforced by CI and used to automatically categorize release notes. Allowed types:
+
+* `feat` — a new feature
+* `fix` — a bug fix
+* `docs` — documentation only changes
+* `perf` — a performance improvement
+* `refactor`, `style`, `test`, `build`, `ci`, `chore` — maintenance work that doesn't change behavior for end users
+* `revert` — reverts a previous commit
+
+Add a `!` right after the type/scope (e.g. `feat!:` or `feat(api)!:`) to flag a breaking change.
+
+Examples:
+
+```
+feat(lag_transforms): add pooled rolling mean
+fix: handle empty series in cross_validation
+perf(core): vectorize lag computation
+docs: fix broken link in quickstart
+chore: bump ruff to 0.9
+feat(api)!: drop support for Python 3.9
+```
+
 * Keep each PR focused. While it's more convenient, do not combine several unrelated fixes together. Create as many branches as needing to keep each PR focused.
 * Ensure that your PR includes a test that fails without your patch, and passes with it.
 * Ensure the PR description clearly describes the problem and solution. Include the relevant issue number if applicable.


### PR DESCRIPTION
## Summary
- Standardize PR titles on [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): subject`) and enforce it in CI via a new `PR Title Lint` workflow (exempts Dependabot PRs).
- Wire the new title convention into `release-drafter` via an `autolabeler` section (title regex → label), and add `Performance`/`Maintenance` categories so drafted release notes get proper sections instead of just features/fixes/docs. Created the `performance` and `chore` labels this relies on.
- Document the required title format and types in `CONTRIBUTING.md`, and update the PR template checklist to reference it.
- Add a `uv` package-ecosystem entry to `dependabot.yml` so Python dependency PRs open automatically on a weekly schedule (previously only `github-actions` was tracked, so Python bumps had to be done manually).
- Add a `Dependabot auto-merge` workflow that auto-enables `gh pr merge --auto` for patch/minor Dependabot bumps (via `dependabot/fetch-metadata`), leaving major bumps for manual review.

## Out of scope
- Making any status check "required" to merge — this repo's branch protection is an Enterprise-managed ruleset with no `required_status_checks` rule, and changing it needs org/enterprise admin access this PR's author doesn't have.
- Enabling Dependabot security-update auto-PRs (a separate repo Settings toggle, not visible without admin) and confirming whether Action-token approvals can satisfy the existing 1-approval branch rule for full hands-off Dependabot auto-merge.

## Test plan

Needs to be merged first before testing.

- [ ] Open a test PR with a non-conforming title (e.g. `random title`) and confirm `PR Title Lint` fails; retitle to `fix: ...` and confirm it passes.
- [ ] Confirm a `feat:`/`fix:`/`docs:`/`perf:`/`chore:` titled PR gets auto-labeled correctly and shows up in the right `release-drafter` draft section.
- [ ] Confirm the next Dependabot run opens a PR for the `uv` ecosystem (or trigger manually).
- [ ] Watch `dependabot-auto-merge.yml` on the next Dependabot PR and confirm it only auto-enables merge for patch/minor bumps, skipping majors.