### PR TITLE
fix: migrate ray models to ray.train

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -94,8 +94,5 @@ jobs:
       - name: Run pytest
         env:
           RAY_ENABLE_UV_RUN_RUNTIME_ENV: 0
-          # ray >=2.56 converts blocks to pandas with pd.ArrowDtype columns, which
-          # lightgbm rejects ("pandas dtypes must be int, float or bool"). Keep the
-          # pre-2.56 numpy dtypes until the ray models cast the features themselves.
-          RAY_DATA_ENABLE_ARROW_BACKED_PANDAS_CONVERSION: 0
-        run: uv run pytest --reruns=2 --reruns-delay=2 --only-rerun="Socket recv error"
+        # --timeout keeps a hung ray test from burning the job's full 6h budget
+        run: uv run pytest --timeout=600 --reruns=2 --reruns-delay=2 --only-rerun="Socket recv error"

--- a/docs/distributed.models.ray.lgb.html.md
+++ b/docs/distributed.models.ray.lgb.html.md
@@ -5,8 +5,8 @@ title: RayLGBMForecast
 ---
 
 
-Wrapper of `lightgbm.ray.RayLGBMRegressor` that adds a `model_` property
-that contains the fitted booster and is sent to the workers to in the
-forecasting step.
+LightGBM forecaster trained with `ray.train.lightgbm.LightGBMTrainer`. Adds a
+`model_` property that contains the fitted booster as a local
+`lightgbm.LGBMRegressor` and is sent to the workers in the forecasting step.
 
 ::: mlforecast.distributed.models.ray.lgb.RayLGBMForecast

--- a/docs/distributed.models.ray.lgb.html.md
+++ b/docs/distributed.models.ray.lgb.html.md
@@ -6,7 +6,7 @@ title: RayLGBMForecast
 
 
 LightGBM forecaster trained with `ray.train.lightgbm.LightGBMTrainer`. Adds a
-`model_` property that contains the fitted booster as a local
+`model_` attribute that contains the fitted booster as a local
 `lightgbm.LGBMRegressor` and is sent to the workers in the forecasting step.
 
 ::: mlforecast.distributed.models.ray.lgb.RayLGBMForecast

--- a/docs/distributed.models.ray.xgb.html.md
+++ b/docs/distributed.models.ray.xgb.html.md
@@ -5,8 +5,8 @@ title: RayXGBForecast
 ---
 
 
-Wrapper of `xgboost.ray.RayXGBRegressor` that adds a `model_` property
-that contains the fitted model and is sent to the workers in the
-forecasting step.
+XGBoost forecaster trained with `ray.train.xgboost.XGBoostTrainer`. Adds a
+`model_` property that contains the fitted booster as a local
+`xgboost.XGBRegressor` and is sent to the workers in the forecasting step.
 
 ::: mlforecast.distributed.models.ray.xgb.RayXGBForecast

--- a/docs/distributed.models.ray.xgb.html.md
+++ b/docs/distributed.models.ray.xgb.html.md
@@ -6,7 +6,7 @@ title: RayXGBForecast
 
 
 XGBoost forecaster trained with `ray.train.xgboost.XGBoostTrainer`. Adds a
-`model_` property that contains the fitted booster as a local
+`model_` attribute that contains the fitted booster as a local
 `xgboost.XGBRegressor` and is sent to the workers in the forecasting step.
 
 ::: mlforecast.distributed.models.ray.xgb.RayXGBForecast

--- a/mlforecast/distributed/forecast.py
+++ b/mlforecast/distributed/forecast.py
@@ -29,7 +29,6 @@ try:
 except ModuleNotFoundError:
     SPARK_INSTALLED = False
 try:
-    from lightgbm_ray import RayDMatrix
     from ray.data import Dataset as RayDataset
 
     RAY_INSTALLED = True
@@ -435,12 +434,8 @@ class DistributedMLForecast:
             prep_selected = prep.select_columns(
                 cols=features + [target_col]
             ).materialize()
-            X = RayDMatrix(
-                prep_selected,
-                label=target_col,
-            )
             for name, model in self.models.items():
-                trained_model = clone(model).fit(X, y=None)
+                trained_model = clone(model).fit(prep_selected, target_col=target_col)
                 self.models_[name] = trained_model.model_
         else:
             raise NotImplementedError(

--- a/mlforecast/distributed/forecast.py
+++ b/mlforecast/distributed/forecast.py
@@ -426,7 +426,8 @@ class DistributedMLForecast:
                 trained_model = clone(model).fit(X, y, sample_weight=weights)
                 self.models_[name] = trained_model.model_
         elif RAY_INSTALLED and isinstance(data, RayDataset):
-            # Need to materialize
+            # Need to materialize. Each model's fit would otherwise re-execute
+            # this same dataset, since they all get handed the lazy one.
             if weight_col is not None:
                 raise NotImplementedError(
                     "Only spark and dask engines currently support sample weights."

--- a/mlforecast/distributed/models/ray/_base.py
+++ b/mlforecast/distributed/models/ray/_base.py
@@ -1,0 +1,87 @@
+__all__ = ["RayForecastBase"]
+
+
+from typing import Any, Callable, Dict, Optional, Tuple
+
+from sklearn.base import BaseEstimator
+
+
+class RayForecastBase(BaseEstimator):
+    """Base for the ray models, trained through ray.train's Trainer API.
+
+    Subclasses provide ``_trainer_cls``, ``_train_loop`` (a module level function,
+    so that it can be shipped to the workers), ``_translate_params`` and
+    ``_local_model``.
+
+    The ray specific arguments are keyword only so that they can't collide with
+    the booster's parameters, which are taken as ``**params``.
+    """
+
+    _trainer_cls: Any
+    _train_loop: Callable[[Dict[str, Any]], None]
+
+    def __init__(
+        self,
+        *,
+        num_workers: int = 1,
+        resources_per_worker: Optional[Dict[str, float]] = None,
+        **params: Any,
+    ):
+        self.num_workers = num_workers
+        self.resources_per_worker = resources_per_worker
+        self.params = params
+
+    # sklearn's introspection ignores **kwargs, which would make `clone` drop
+    # every booster parameter, so the params are handled explicitly here.
+    def get_params(self, deep: bool = True) -> Dict[str, Any]:  # noqa: ARG002 - sklearn's signature
+        return {
+            "num_workers": self.num_workers,
+            "resources_per_worker": self.resources_per_worker,
+            **self.params,
+        }
+
+    def set_params(self, **params: Any) -> "RayForecastBase":
+        for name in ("num_workers", "resources_per_worker"):
+            if name in params:
+                setattr(self, name, params.pop(name))
+        self.params.update(params)
+        return self
+
+    def _translate_params(self) -> Tuple[Dict[str, Any], int]:
+        """Return the booster params and the number of boosting rounds."""
+        raise NotImplementedError
+
+    def _local_model(self, checkpoint: Any, params: Dict[str, Any]) -> Any:
+        """Rebuild a local (non-distributed) model from the training checkpoint."""
+        raise NotImplementedError
+
+    def fit(self, dataset: Any, target_col: str) -> "RayForecastBase":
+        from ray.train import ScalingConfig
+
+        params, num_boost_round = self._translate_params()
+        trainer = self._trainer_cls(
+            self._train_loop,
+            train_loop_config={
+                "params": params,
+                "num_boost_round": num_boost_round,
+                "target_col": target_col,
+            },
+            scaling_config=ScalingConfig(
+                num_workers=self.num_workers,
+                resources_per_worker=self.resources_per_worker,
+            ),
+            datasets={"train": dataset},
+        )
+        result = trainer.fit()
+        self.model_ = self._local_model(result.checkpoint, params)
+        return self
+
+    def _pop_num_boost_round(self, params: Dict[str, Any], *aliases: str) -> int:
+        for alias in aliases:
+            if alias in params:
+                num_boost_round = params.pop(alias)
+                # drop any remaining aliases so they don't reach the booster
+                for other in aliases:
+                    params.pop(other, None)
+                return int(num_boost_round)
+        return 100

--- a/mlforecast/distributed/models/ray/_base.py
+++ b/mlforecast/distributed/models/ray/_base.py
@@ -1,87 +1,116 @@
 __all__ = ["RayForecastBase"]
 
 
-from typing import Any, Callable, Dict, Optional, Tuple
+import pickle
+import tempfile
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
 
-from sklearn.base import BaseEstimator
+_RAY_PARAMS = ("num_workers", "resources_per_worker")
+_MODEL_FILE = "model.pkl"
 
 
-class RayForecastBase(BaseEstimator):
-    """Base for the ray models, trained through ray.train's Trainer API.
+def worker_n_jobs(requested: Any) -> int:
+    """Threads for the booster, from the CPUs this train worker was actually given.
 
-    Subclasses provide ``_trainer_cls``, ``_train_loop`` (a module level function,
-    so that it can be shipped to the workers), ``_translate_params`` and
-    ``_local_model``.
+    Both ``lightgbm_ray`` and ``xgboost_ray`` sized the thread pool from the
+    actor's CPU share; without it N workers landing on one node each spawn
+    threads for every core on the box. An explicit, smaller value is honoured.
+    """
+    import ray
+
+    assigned = ray.get_runtime_context().get_assigned_resources().get("CPU", 1)
+    assigned = max(1, int(assigned))
+    try:
+        requested = int(requested)
+    except (TypeError, ValueError):
+        return assigned
+    return assigned if requested <= 0 else min(requested, assigned)
+
+
+class KeepLastMetrics:
+    """Remember the last iteration's metrics so the final report can carry them."""
+
+    last_metrics: Dict[str, Any] = {}
+
+    def _report_metrics(self, report_dict: Dict[str, Any]) -> None:
+        self.last_metrics = report_dict
+        super()._report_metrics(report_dict)  # type: ignore[misc]
+
+
+def report_fitted_model(
+    model: Any, booster: Any, booster_file: str, metrics: Dict[str, Any]
+) -> None:
+    """Report ray's standard booster artifact along with the fitted estimator.
+
+    The estimator is what becomes ``model_``, which is why it's checkpointed;
+    the booster is kept next to it so that ``RayTrainReportCallback.get_model``
+    still works on the result.
+
+    ``ray.train.report`` is collective, so every worker has to call it;
+    reporting from rank 0 only deadlocks.
+    """
+    import ray.train
+    from ray.train import Checkpoint
+
+    if ray.train.get_context().get_world_rank() != 0:
+        ray.train.report(metrics)
+        return
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        booster.save_model(Path(tmp_dir, booster_file).as_posix())
+        with open(Path(tmp_dir, _MODEL_FILE), "wb") as f:
+            pickle.dump(model, f)
+        ray.train.report(metrics, checkpoint=Checkpoint.from_directory(tmp_dir))
+
+
+class RayForecastBase:
+    """Mixin holding the ray.train plumbing; subclasses are real sklearn estimators.
+
+    The training loop builds and fits the library's own estimator in the worker,
+    as ``lightgbm.dask._train_part`` does, and checkpoints it. That keeps all of
+    the parameter handling in the library instead of here.
 
     The ray specific arguments are keyword only so that they can't collide with
-    the booster's parameters, which are taken as ``**params``.
+    the booster's parameters, which are taken as ``**kwargs``.
     """
 
-    _trainer_cls: Any
-    _train_loop: Callable[[Dict[str, Any]], None]
+    num_workers: int
+    resources_per_worker: Optional[Dict[str, float]]
 
     def __init__(
         self,
         *,
         num_workers: int = 1,
         resources_per_worker: Optional[Dict[str, float]] = None,
-        **params: Any,
+        **kwargs: Any,
     ):
+        # cooperative: goes on to LGBMRegressor / XGBRegressor
+        super().__init__(**kwargs)
         self.num_workers = num_workers
         self.resources_per_worker = resources_per_worker
-        self.params = params
 
-    # sklearn's introspection ignores **kwargs, which would make `clone` drop
-    # every booster parameter, so the params are handled explicitly here.
-    def get_params(self, deep: bool = True) -> Dict[str, Any]:  # noqa: ARG002 - sklearn's signature
-        return {
-            "num_workers": self.num_workers,
-            "resources_per_worker": self.resources_per_worker,
-            **self.params,
-        }
-
-    def set_params(self, **params: Any) -> "RayForecastBase":
-        for name in ("num_workers", "resources_per_worker"):
-            if name in params:
-                setattr(self, name, params.pop(name))
-        self.params.update(params)
-        return self
-
-    def _translate_params(self) -> Tuple[Dict[str, Any], int]:
-        """Return the booster params and the number of boosting rounds."""
-        raise NotImplementedError
-
-    def _local_model(self, checkpoint: Any, params: Dict[str, Any]) -> Any:
-        """Rebuild a local (non-distributed) model from the training checkpoint."""
-        raise NotImplementedError
-
-    def fit(self, dataset: Any, target_col: str) -> "RayForecastBase":
+    def _train(
+        self,
+        trainer_cls: Any,
+        train_loop: Callable[[Dict[str, Any]], None],
+        dataset: Any,
+        target_col: str,
+    ) -> "RayForecastBase":
         from ray.train import ScalingConfig
 
-        params, num_boost_round = self._translate_params()
-        trainer = self._trainer_cls(
-            self._train_loop,
-            train_loop_config={
-                "params": params,
-                "num_boost_round": num_boost_round,
-                "target_col": target_col,
-            },
+        params = self.get_params()  # type: ignore[attr-defined]
+        for name in _RAY_PARAMS:
+            params.pop(name, None)
+        trainer = trainer_cls(
+            train_loop,
+            train_loop_config={"params": params, "target_col": target_col},
             scaling_config=ScalingConfig(
                 num_workers=self.num_workers,
                 resources_per_worker=self.resources_per_worker,
             ),
             datasets={"train": dataset},
         )
-        result = trainer.fit()
-        self.model_ = self._local_model(result.checkpoint, params)
+        with trainer.fit().checkpoint.as_directory() as ckpt_dir:
+            with open(Path(ckpt_dir, _MODEL_FILE), "rb") as f:
+                self.model_ = pickle.load(f)
         return self
-
-    def _pop_num_boost_round(self, params: Dict[str, Any], *aliases: str) -> int:
-        for alias in aliases:
-            if alias in params:
-                num_boost_round = params.pop(alias)
-                # drop any remaining aliases so they don't reach the booster
-                for other in aliases:
-                    params.pop(other, None)
-                return int(num_boost_round)
-        return 100

--- a/mlforecast/distributed/models/ray/_base.py
+++ b/mlforecast/distributed/models/ray/_base.py
@@ -99,14 +99,32 @@ class RayForecastBase:
         ``ScalingConfig`` assigns a single CPU per worker when this isn't set,
         which would make a default fit single threaded. ``xgboost_ray`` split the
         cluster's CPUs across its actors instead (``_autodetect_resources``);
-        that's kept here so that the default isn't a slowdown.
+        that's kept here so that the default isn't a slowdown, bound by the
+        smallest node included.
+
+        The share also becomes ray data's ``exclude_resources``
+        (``DataParallelTrainer`` hands it ``scaling_config.total_resources``), so
+        a worker that takes every CPU on its node leaves data none to execute
+        with. ``_train`` materializes before building the trainer so that there
+        is nothing left for data to do by then.
         """
         import ray
 
         if self.resources_per_worker is not None:
             return self.resources_per_worker
         cpus = int(ray.cluster_resources().get("CPU", 1))
-        return {"CPU": max(1, cpus // self.num_workers)}
+        # a placement group bundle has to fit on a single node, so the cluster
+        # wide share is bounded by the smallest one as well
+        min_node_cpus = min(
+            (
+                node.get("Resources", {}).get("CPU", 0.0)
+                for node in ray.nodes()
+                if node.get("Alive", False)
+            ),
+            default=0.0,
+        )
+        share = min(int(min_node_cpus or 1), cpus // self.num_workers)
+        return {"CPU": max(1, share)}
 
     def _train(
         self,
@@ -120,6 +138,13 @@ class RayForecastBase:
         params = self.get_params()  # type: ignore[attr-defined]
         for name in _RAY_PARAMS:
             params.pop(name, None)
+        # execute the dataset before the trainer exists. ray train reserves the
+        # workers' CPUs away from ray data (`ScalingConfig.total_resources`
+        # becomes data's `exclude_resources`), so a dataset with work still
+        # pending once the placement group holds them has nothing left to run
+        # with and blocks forever. Nothing is given up by doing it here: the
+        # train loops build a `Dataset`/`DMatrix` from the whole shard anyway.
+        dataset = dataset.materialize()
         with contextlib.ExitStack() as stack:
             storage_path = self.storage_path
             if storage_path is None:

--- a/mlforecast/distributed/models/ray/_base.py
+++ b/mlforecast/distributed/models/ray/_base.py
@@ -1,12 +1,13 @@
 __all__ = ["RayForecastBase"]
 
 
+import contextlib
 import pickle
 import tempfile
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional
 
-_RAY_PARAMS = ("num_workers", "resources_per_worker")
+_RAY_PARAMS = ("num_workers", "resources_per_worker", "storage_path")
 _MODEL_FILE = "model.pkl"
 
 
@@ -76,18 +77,36 @@ class RayForecastBase:
 
     num_workers: int
     resources_per_worker: Optional[Dict[str, float]]
+    storage_path: Optional[str]
 
     def __init__(
         self,
         *,
         num_workers: int = 1,
         resources_per_worker: Optional[Dict[str, float]] = None,
+        storage_path: Optional[str] = None,
         **kwargs: Any,
     ):
         # cooperative: goes on to LGBMRegressor / XGBRegressor
         super().__init__(**kwargs)
         self.num_workers = num_workers
         self.resources_per_worker = resources_per_worker
+        self.storage_path = storage_path
+
+    def _resources_per_worker(self) -> Dict[str, float]:
+        """The CPUs each worker gets, and therefore the booster's thread count.
+
+        ``ScalingConfig`` assigns a single CPU per worker when this isn't set,
+        which would make a default fit single threaded. ``xgboost_ray`` split the
+        cluster's CPUs across its actors instead (``_autodetect_resources``);
+        that's kept here so that the default isn't a slowdown.
+        """
+        import ray
+
+        if self.resources_per_worker is not None:
+            return self.resources_per_worker
+        cpus = int(ray.cluster_resources().get("CPU", 1))
+        return {"CPU": max(1, cpus // self.num_workers)}
 
     def _train(
         self,
@@ -96,21 +115,28 @@ class RayForecastBase:
         dataset: Any,
         target_col: str,
     ) -> "RayForecastBase":
-        from ray.train import ScalingConfig
+        from ray.train import RunConfig, ScalingConfig
 
         params = self.get_params()  # type: ignore[attr-defined]
         for name in _RAY_PARAMS:
             params.pop(name, None)
-        trainer = trainer_cls(
-            train_loop,
-            train_loop_config={"params": params, "target_col": target_col},
-            scaling_config=ScalingConfig(
-                num_workers=self.num_workers,
-                resources_per_worker=self.resources_per_worker,
-            ),
-            datasets={"train": dataset},
-        )
-        with trainer.fit().checkpoint.as_directory() as ckpt_dir:
-            with open(Path(ckpt_dir, _MODEL_FILE), "rb") as f:
-                self.model_ = pickle.load(f)
+        with contextlib.ExitStack() as stack:
+            storage_path = self.storage_path
+            if storage_path is None:
+                # the default (~/ray_results) would grow by one run per model per
+                # fit, which neither of the previous wrappers did.
+                storage_path = stack.enter_context(tempfile.TemporaryDirectory())
+            trainer = trainer_cls(
+                train_loop,
+                train_loop_config={"params": params, "target_col": target_col},
+                scaling_config=ScalingConfig(
+                    num_workers=self.num_workers,
+                    resources_per_worker=self._resources_per_worker(),
+                ),
+                run_config=RunConfig(storage_path=storage_path),
+                datasets={"train": dataset},
+            )
+            with trainer.fit().checkpoint.as_directory() as ckpt_dir:
+                with open(Path(ckpt_dir, _MODEL_FILE), "rb") as f:
+                    self.model_ = pickle.load(f)
         return self

--- a/mlforecast/distributed/models/ray/lgb.py
+++ b/mlforecast/distributed/models/ray/lgb.py
@@ -1,74 +1,81 @@
 __all__ = ["RayLGBMForecast"]
 
 
-from typing import Any, Dict, Tuple
+from typing import Any, Dict
 
 import lightgbm as lgb
 
-from ._base import RayForecastBase
+from ._base import (
+    _RAY_PARAMS,
+    KeepLastMetrics,
+    RayForecastBase,
+    report_fitted_model,
+    worker_n_jobs,
+)
 
 
 def _lgb_train_loop(config: Dict[str, Any]) -> None:
     import ray.train
     from ray.train.lightgbm import (
         RayTrainReportCallback,
+        get_network_params,
         normalize_pandas_for_lightgbm,
     )
+
+    class _ReportCallback(KeepLastMetrics, RayTrainReportCallback):
+        pass
 
     shard = ray.train.get_dataset_shard("train")
     # since ray 2.56 to_pandas yields pd.ArrowDtype columns, which lightgbm's
     # input validation rejects, so they're mapped back to numpy dtypes here.
     df = normalize_pandas_for_lightgbm(shard.materialize().to_pandas())
     label = df.pop(config["target_col"])
-    train_set = lgb.Dataset(df, label=label)
-    lgb.train(
-        config["params"],
-        train_set,
-        num_boost_round=config["num_boost_round"],
-        valid_sets=[train_set],
-        valid_names=["train"],
-        callbacks=[RayTrainReportCallback()],
+    params = {
+        **config["params"],
+        "n_jobs": worker_n_jobs(config["params"].get("n_jobs")),
+    }
+    callback = _ReportCallback(checkpoint_at_end=False)
+    # each worker only sees its own shard. ray's LightGBMConfig stashes the
+    # network params in a per worker global rather than injecting them, so
+    # without these every worker trains an independent model on 1/N of the data
+    # and rank 0's is the one that gets checkpointed. Plain kwargs, as in
+    # lightgbm.dask's _train_part.
+    model = lgb.LGBMRegressor(
+        **params, tree_learner="data_parallel", **get_network_params()
+    )
+    model.fit(
+        df, label, eval_set=[(df, label)], eval_names=["train"], callbacks=[callback]
+    )
+    report_fitted_model(
+        model, model.booster_, _ReportCallback.CHECKPOINT_NAME, callback.last_metrics
     )
 
 
-class RayLGBMForecast(RayForecastBase):
-    _train_loop = staticmethod(_lgb_train_loop)
+class RayLGBMForecast(RayForecastBase, lgb.LGBMRegressor):
+    """LightGBM forecaster trained with `ray.train.lightgbm.LightGBMTrainer`.
 
-    @property
-    def _trainer_cls(self):
+    The booster's parameters are taken as ``**kwargs`` and handled by
+    ``LGBMRegressor`` itself; ``num_workers`` and ``resources_per_worker`` are
+    keyword only so that they can't collide with them.
+
+    ``num_workers`` sets the number of ray train workers. The previous
+    ``lightgbm_ray`` based implementation derived that from ``n_jobs``
+    (``RayParams(num_actors=n_jobs)``); ``n_jobs`` is now the per worker thread
+    count, as it is for the local estimator.
+
+    ``fit`` takes a ray ``Dataset`` and a target column rather than the sklearn
+    ``(X, y)`` pair, as the previous implementation did, so the inherited
+    ``predict``/``score`` can't be used before fitting. The fitted estimator is
+    exposed as ``model_``, a local ``lightgbm.LGBMRegressor`` that is sent to the
+    workers in the forecasting step.
+    """
+
+    @classmethod
+    def _get_param_names(cls):
+        # sklearn reads the subclass' signature, which doesn't name the booster params
+        return sorted([*lgb.LGBMRegressor._get_param_names(), *_RAY_PARAMS])
+
+    def fit(self, dataset: Any, target_col: str) -> "RayLGBMForecast":  # type: ignore[override]
         from ray.train.lightgbm import LightGBMTrainer
 
-        return LightGBMTrainer
-
-    def _translate_params(self) -> Tuple[Dict[str, Any], int]:
-        params = dict(self.params)
-        # lightgbm takes random_state as an alias of seed, so only the number of
-        # rounds has to be lifted out of the params.
-        num_boost_round = self._pop_num_boost_round(
-            params, "n_estimators", "num_iterations", "num_boost_round"
-        )
-        params.setdefault("objective", "regression")
-        return params, num_boost_round
-
-    def _local_model(
-        self, checkpoint: Any, params: Dict[str, Any]
-    ) -> lgb.LGBMRegressor:
-        from ray.train.lightgbm import RayTrainReportCallback
-
-        booster = RayTrainReportCallback.get_model(checkpoint)
-        model = lgb.LGBMRegressor(**params)
-        # mirrors what lightgbm_ray's _lgb_ray_to_local did: build the local
-        # estimator from the params and graft the trained booster onto it.
-        model._Booster = booster
-        model.fitted_ = True
-        model._n_features = booster.num_feature()
-        model._n_features_in = booster.num_feature()
-        model._best_iteration = booster.best_iteration
-        model._best_score = {}
-        model._evals_result = {}
-        model._objective = params["objective"]
-        model._le = None
-        model._class_map = None
-        model._classes = None
-        model._n_classes = -1
-        return model
+        return self._train(LightGBMTrainer, _lgb_train_loop, dataset, target_col)  # type: ignore[return-value]

--- a/mlforecast/distributed/models/ray/lgb.py
+++ b/mlforecast/distributed/models/ray/lgb.py
@@ -1,11 +1,74 @@
 __all__ = ["RayLGBMForecast"]
 
 
+from typing import Any, Dict, Tuple
+
 import lightgbm as lgb
-from lightgbm_ray import RayLGBMRegressor
+
+from ._base import RayForecastBase
 
 
-class RayLGBMForecast(RayLGBMRegressor):
+def _lgb_train_loop(config: Dict[str, Any]) -> None:
+    import ray.train
+    from ray.train.lightgbm import (
+        RayTrainReportCallback,
+        normalize_pandas_for_lightgbm,
+    )
+
+    shard = ray.train.get_dataset_shard("train")
+    # since ray 2.56 to_pandas yields pd.ArrowDtype columns, which lightgbm's
+    # input validation rejects, so they're mapped back to numpy dtypes here.
+    df = normalize_pandas_for_lightgbm(shard.materialize().to_pandas())
+    label = df.pop(config["target_col"])
+    train_set = lgb.Dataset(df, label=label)
+    lgb.train(
+        config["params"],
+        train_set,
+        num_boost_round=config["num_boost_round"],
+        valid_sets=[train_set],
+        valid_names=["train"],
+        callbacks=[RayTrainReportCallback()],
+    )
+
+
+class RayLGBMForecast(RayForecastBase):
+    _train_loop = staticmethod(_lgb_train_loop)
+
     @property
-    def model_(self):
-        return self._lgb_ray_to_local(lgb.LGBMRegressor)
+    def _trainer_cls(self):
+        from ray.train.lightgbm import LightGBMTrainer
+
+        return LightGBMTrainer
+
+    def _translate_params(self) -> Tuple[Dict[str, Any], int]:
+        params = dict(self.params)
+        # lightgbm takes random_state as an alias of seed, so only the number of
+        # rounds has to be lifted out of the params.
+        num_boost_round = self._pop_num_boost_round(
+            params, "n_estimators", "num_iterations", "num_boost_round"
+        )
+        params.setdefault("objective", "regression")
+        return params, num_boost_round
+
+    def _local_model(
+        self, checkpoint: Any, params: Dict[str, Any]
+    ) -> lgb.LGBMRegressor:
+        from ray.train.lightgbm import RayTrainReportCallback
+
+        booster = RayTrainReportCallback.get_model(checkpoint)
+        model = lgb.LGBMRegressor(**params)
+        # mirrors what lightgbm_ray's _lgb_ray_to_local did: build the local
+        # estimator from the params and graft the trained booster onto it.
+        model._Booster = booster
+        model.fitted_ = True
+        model._n_features = booster.num_feature()
+        model._n_features_in = booster.num_feature()
+        model._best_iteration = booster.best_iteration
+        model._best_score = {}
+        model._evals_result = {}
+        model._objective = params["objective"]
+        model._le = None
+        model._class_map = None
+        model._classes = None
+        model._n_classes = -1
+        return model

--- a/mlforecast/distributed/models/ray/lgb.py
+++ b/mlforecast/distributed/models/ray/lgb.py
@@ -46,6 +46,9 @@ def _lgb_train_loop(config: Dict[str, Any]) -> None:
     model.fit(
         df, label, eval_set=[(df, label)], eval_names=["train"], callbacks=[callback]
     )
+    # the clamp is for this worker's thread pool; model_ is shipped to the
+    # forecasting workers and returned by to_local, so it keeps what was asked for
+    model.set_params(n_jobs=config["params"].get("n_jobs"))
     report_fitted_model(
         model, model.booster_, _ReportCallback.CHECKPOINT_NAME, callback.last_metrics
     )
@@ -55,13 +58,25 @@ class RayLGBMForecast(RayForecastBase, lgb.LGBMRegressor):
     """LightGBM forecaster trained with `ray.train.lightgbm.LightGBMTrainer`.
 
     The booster's parameters are taken as ``**kwargs`` and handled by
-    ``LGBMRegressor`` itself; ``num_workers`` and ``resources_per_worker`` are
-    keyword only so that they can't collide with them.
+    ``LGBMRegressor`` itself; the ray arguments are keyword only
+    so that they can't collide with them.
 
     ``num_workers`` sets the number of ray train workers. The previous
     ``lightgbm_ray`` based implementation derived that from ``n_jobs``
     (``RayParams(num_actors=n_jobs)``); ``n_jobs`` is now the per worker thread
     count, as it is for the local estimator.
+
+    ``resources_per_worker`` is the CPU knob: it decides how many CPUs each
+    worker is given and therefore how many threads the booster can use. It
+    defaults to the cluster's CPUs split evenly across the workers, as
+    ``xgboost_ray._autodetect_resources`` did, and ``n_jobs`` can only lower it
+    below that share. ``model_`` keeps the requested ``n_jobs`` rather than the clamp.
+
+    ``storage_path`` is where ray train writes the run. It defaults to a
+    temporary directory that is discarded once the fitted model has been read
+    back, so that ``~/ray_results`` doesn't grow by a run per model per fit; as
+    with ray's own default, a local path only works on a single node, so point
+    it at shared storage for a multi node cluster.
 
     ``fit`` takes a ray ``Dataset`` and a target column rather than the sklearn
     ``(X, y)`` pair, as the previous implementation did, so the inherited

--- a/mlforecast/distributed/models/ray/lgb.py
+++ b/mlforecast/distributed/models/ray/lgb.py
@@ -68,9 +68,10 @@ class RayLGBMForecast(RayForecastBase, lgb.LGBMRegressor):
 
     ``resources_per_worker`` is the CPU knob: it decides how many CPUs each
     worker is given and therefore how many threads the booster can use. It
-    defaults to the cluster's CPUs split evenly across the workers, as
-    ``xgboost_ray._autodetect_resources`` did, and ``n_jobs`` can only lower it
-    below that share. ``model_`` keeps the requested ``n_jobs`` rather than the clamp.
+    defaults to the cluster's CPUs split evenly across the workers and bounded by
+    the smallest node, as ``xgboost_ray._autodetect_resources`` did, and ``n_jobs``
+    can only lower it below that share. ``model_`` keeps the requested ``n_jobs``
+    rather than the clamp.
 
     ``storage_path`` is where ray train writes the run. It defaults to a
     temporary directory that is discarded once the fitted model has been read

--- a/mlforecast/distributed/models/ray/xgb.py
+++ b/mlforecast/distributed/models/ray/xgb.py
@@ -1,61 +1,67 @@
 __all__ = ["RayXGBForecast"]
 
 
-from typing import Any, Dict, Tuple
+from typing import Any, Dict
 
 import xgboost as xgb
 
-from ._base import RayForecastBase
+from ._base import KeepLastMetrics, RayForecastBase, report_fitted_model, worker_n_jobs
 
 
 def _xgb_train_loop(config: Dict[str, Any]) -> None:
     import ray.train
     from ray.train.xgboost import RayTrainReportCallback
 
+    class _ReportCallback(KeepLastMetrics, RayTrainReportCallback):
+        pass
+
     shard = ray.train.get_dataset_shard("train")
     # unlike lightgbm, xgboost accepts arrow backed pandas columns.
     df = shard.materialize().to_pandas()
     label = df.pop(config["target_col"])
-    dtrain = xgb.DMatrix(df, label=label)
-    xgb.train(
-        config["params"],
-        dtrain,
-        num_boost_round=config["num_boost_round"],
-        evals=[(dtrain, "train")],
-        callbacks=[RayTrainReportCallback()],
+    callback = _ReportCallback(checkpoint_at_end=False)
+    params = {
+        **config["params"],
+        "n_jobs": worker_n_jobs(config["params"].get("n_jobs")),
+        # get_params already carries a callbacks key, so it has to be merged in
+        # rather than passed alongside.
+        "callbacks": [callback],
+    }
+    # XGBoostConfig wraps the loop in a CommunicatorContext, so unlike lightgbm
+    # there are no network params to pass: training is distributed already.
+    model = xgb.XGBRegressor(**params)
+    model.fit(df, label, eval_set=[(df, label)])
+    # xgboost keeps callbacks as a parameter, so without this the ray callback
+    # rides back to the driver and into DistributedMLForecast.save's pickle.
+    model.set_params(callbacks=None)
+    report_fitted_model(
+        model,
+        model.get_booster(),
+        _ReportCallback.CHECKPOINT_NAME,
+        callback.last_metrics,
     )
 
 
-class RayXGBForecast(RayForecastBase):
-    _train_loop = staticmethod(_xgb_train_loop)
+class RayXGBForecast(RayForecastBase, xgb.XGBRegressor):
+    """XGBoost forecaster trained with `ray.train.xgboost.XGBoostTrainer`.
 
-    @property
-    def _trainer_cls(self):
+    The booster's parameters are taken as ``**kwargs`` and handled by
+    ``XGBRegressor`` itself; ``num_workers`` and ``resources_per_worker`` are
+    keyword only so that they can't collide with them.
+
+    ``num_workers`` sets the number of ray train workers. The previous
+    ``xgboost_ray`` based implementation derived that from ``n_jobs``
+    (``RayParams(num_actors=n_jobs)``); ``n_jobs`` is now the per worker thread
+    count, as it is for the local estimator.
+
+    ``fit`` takes a ray ``Dataset`` and a target column rather than the sklearn
+    ``(X, y)`` pair, as the previous implementation did, so the inherited
+    ``predict``/``score`` can't be used before fitting. The fitted estimator is
+    exposed as ``model_``, a local ``xgboost.XGBRegressor`` that is sent to the
+    workers in the forecasting step.
+    """
+
+    def fit(self, dataset: Any, target_col: str) -> "RayXGBForecast":  # type: ignore[override]
         from ray.train.xgboost import XGBoostTrainer
 
-        return XGBoostTrainer
-
-    def _translate_params(self) -> Tuple[Dict[str, Any], int]:
-        params = dict(self.params)
-        num_boost_round = self._pop_num_boost_round(
-            params, "n_estimators", "num_boost_round"
-        )
-        # the native API doesn't know about the sklearn parameter names
-        if "random_state" in params:
-            params["seed"] = params.pop("random_state")
-        params.setdefault("objective", "reg:squarederror")
-        return params, num_boost_round
-
-    def _local_model(
-        self,
-        checkpoint: Any,
-        params: Dict[str, Any],  # noqa: ARG002 - the base class' signature
-    ) -> xgb.XGBRegressor:
-        from ray.train.xgboost import RayTrainReportCallback
-
-        booster = RayTrainReportCallback.get_model(checkpoint)
-        # load_model restores the params from the booster itself, so unlike
-        # lightgbm there's nothing to graft on.
-        model = xgb.XGBRegressor()
-        model.load_model(booster.save_raw("ubj"))
-        return model
+        return self._train(XGBoostTrainer, _xgb_train_loop, dataset, target_col)  # type: ignore[return-value]

--- a/mlforecast/distributed/models/ray/xgb.py
+++ b/mlforecast/distributed/models/ray/xgb.py
@@ -1,14 +1,61 @@
 __all__ = ["RayXGBForecast"]
 
 
+from typing import Any, Dict, Tuple
+
 import xgboost as xgb
-from xgboost_ray import RayXGBRegressor
+
+from ._base import RayForecastBase
 
 
-class RayXGBForecast(RayXGBRegressor):
+def _xgb_train_loop(config: Dict[str, Any]) -> None:
+    import ray.train
+    from ray.train.xgboost import RayTrainReportCallback
+
+    shard = ray.train.get_dataset_shard("train")
+    # unlike lightgbm, xgboost accepts arrow backed pandas columns.
+    df = shard.materialize().to_pandas()
+    label = df.pop(config["target_col"])
+    dtrain = xgb.DMatrix(df, label=label)
+    xgb.train(
+        config["params"],
+        dtrain,
+        num_boost_round=config["num_boost_round"],
+        evals=[(dtrain, "train")],
+        callbacks=[RayTrainReportCallback()],
+    )
+
+
+class RayXGBForecast(RayForecastBase):
+    _train_loop = staticmethod(_xgb_train_loop)
+
     @property
-    def model_(self):
-        model_str = self.get_booster().save_raw("ubj")
-        local_model = xgb.XGBRegressor()
-        local_model.load_model(model_str)
-        return local_model
+    def _trainer_cls(self):
+        from ray.train.xgboost import XGBoostTrainer
+
+        return XGBoostTrainer
+
+    def _translate_params(self) -> Tuple[Dict[str, Any], int]:
+        params = dict(self.params)
+        num_boost_round = self._pop_num_boost_round(
+            params, "n_estimators", "num_boost_round"
+        )
+        # the native API doesn't know about the sklearn parameter names
+        if "random_state" in params:
+            params["seed"] = params.pop("random_state")
+        params.setdefault("objective", "reg:squarederror")
+        return params, num_boost_round
+
+    def _local_model(
+        self,
+        checkpoint: Any,
+        params: Dict[str, Any],  # noqa: ARG002 - the base class' signature
+    ) -> xgb.XGBRegressor:
+        from ray.train.xgboost import RayTrainReportCallback
+
+        booster = RayTrainReportCallback.get_model(checkpoint)
+        # load_model restores the params from the booster itself, so unlike
+        # lightgbm there's nothing to graft on.
+        model = xgb.XGBRegressor()
+        model.load_model(booster.save_raw("ubj"))
+        return model

--- a/mlforecast/distributed/models/ray/xgb.py
+++ b/mlforecast/distributed/models/ray/xgb.py
@@ -33,7 +33,9 @@ def _xgb_train_loop(config: Dict[str, Any]) -> None:
     model.fit(df, label, eval_set=[(df, label)])
     # xgboost keeps callbacks as a parameter, so without this the ray callback
     # rides back to the driver and into DistributedMLForecast.save's pickle.
-    model.set_params(callbacks=None)
+    # the n_jobs clamp is for this worker's thread pool; model_ is shipped to the
+    # forecasting workers and returned by to_local, so it keeps what was asked for
+    model.set_params(callbacks=None, n_jobs=config["params"].get("n_jobs"))
     report_fitted_model(
         model,
         model.get_booster(),
@@ -46,13 +48,25 @@ class RayXGBForecast(RayForecastBase, xgb.XGBRegressor):
     """XGBoost forecaster trained with `ray.train.xgboost.XGBoostTrainer`.
 
     The booster's parameters are taken as ``**kwargs`` and handled by
-    ``XGBRegressor`` itself; ``num_workers`` and ``resources_per_worker`` are
-    keyword only so that they can't collide with them.
+    ``XGBRegressor`` itself; the ray arguments are keyword only
+    so that they can't collide with them.
 
     ``num_workers`` sets the number of ray train workers. The previous
     ``xgboost_ray`` based implementation derived that from ``n_jobs``
     (``RayParams(num_actors=n_jobs)``); ``n_jobs`` is now the per worker thread
     count, as it is for the local estimator.
+
+    ``resources_per_worker`` is the CPU knob: it decides how many CPUs each
+    worker is given and therefore how many threads the booster can use. It
+    defaults to the cluster's CPUs split evenly across the workers, as
+    ``xgboost_ray._autodetect_resources`` did, and ``n_jobs`` can only lower it
+    below that share. ``model_`` keeps the requested ``n_jobs`` rather than the clamp.
+
+    ``storage_path`` is where ray train writes the run. It defaults to a
+    temporary directory that is discarded once the fitted model has been read
+    back, so that ``~/ray_results`` doesn't grow by a run per model per fit; as
+    with ray's own default, a local path only works on a single node, so point
+    it at shared storage for a multi node cluster.
 
     ``fit`` takes a ray ``Dataset`` and a target column rather than the sklearn
     ``(X, y)`` pair, as the previous implementation did, so the inherited

--- a/mlforecast/distributed/models/ray/xgb.py
+++ b/mlforecast/distributed/models/ray/xgb.py
@@ -58,9 +58,10 @@ class RayXGBForecast(RayForecastBase, xgb.XGBRegressor):
 
     ``resources_per_worker`` is the CPU knob: it decides how many CPUs each
     worker is given and therefore how many threads the booster can use. It
-    defaults to the cluster's CPUs split evenly across the workers, as
-    ``xgboost_ray._autodetect_resources`` did, and ``n_jobs`` can only lower it
-    below that share. ``model_`` keeps the requested ``n_jobs`` rather than the clamp.
+    defaults to the cluster's CPUs split evenly across the workers and bounded by
+    the smallest node, as ``xgboost_ray._autodetect_resources`` did, and ``n_jobs``
+    can only lower it below that share. ``model_`` keeps the requested ``n_jobs``
+    rather than the clamp.
 
     ``storage_path`` is where ray train writes the run. It defaults to a
     temporary directory that is discarded once the fitted model has been read

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,8 @@ Documentation = "https://nixtlaverse.nixtla.io/mlforecast/"
 dask = ["fugue[dask]>=0.9.4", "dask[complete]", "lightgbm", "xgboost"]
 ray = [
     "fugue[ray]>=0.9.4; sys_platform != 'win32' and python_version < '3.14'",
-    "lightgbm_ray; sys_platform != 'win32' and python_version < '3.14'",
-    "xgboost_ray>=0.1.19; sys_platform != 'win32' and python_version < '3.14'",
+    "ray[data,train]>=2.56; sys_platform != 'win32' and python_version < '3.14'",
+    "lightgbm>=4.6; sys_platform != 'win32' and python_version < '3.14'",
     "xgboost>=2.0.0,<2.1.0; sys_platform != 'win32' and python_version < '3.14'"
 ]
 spark = ["fugue[spark]>=0.9.4", "pyspark>=3.3", "lightgbm", "xgboost"]
@@ -78,6 +78,7 @@ dev = [
     "pytest-xdist",
     "pytest-codspeed",
     "pytest-rerunfailures",
+    "pytest-timeout",
     "mkdocstrings-parser @ git+https://github.com/Nixtla/mkdocstrings-parser@main"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,10 +41,10 @@ Documentation = "https://nixtlaverse.nixtla.io/mlforecast/"
 [project.optional-dependencies]
 dask = ["fugue[dask]>=0.9.4", "dask[complete]", "lightgbm", "xgboost"]
 ray = [
-    "fugue[ray]>=0.9.4; sys_platform != 'win32' and python_version < '3.14'",
-    "ray[data,train]>=2.56; sys_platform != 'win32' and python_version < '3.14'",
-    "lightgbm>=4.6; sys_platform != 'win32' and python_version < '3.14'",
-    "xgboost>=2.0.0,<2.1.0; sys_platform != 'win32' and python_version < '3.14'"
+    "fugue[ray]>=0.9.4; sys_platform != 'win32'",
+    "ray[data,train]>=2.56; sys_platform != 'win32'",
+    "lightgbm>=4.6; sys_platform != 'win32'",
+    "xgboost>=2.0.0,<2.1.0; sys_platform != 'win32'"
 ]
 spark = ["fugue[spark]>=0.9.4", "pyspark>=3.3", "lightgbm", "xgboost"]
 aws = ["fsspec[s3]"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ ray = [
     "fugue[ray]>=0.9.4; sys_platform != 'win32'",
     "ray[data,train]>=2.56; sys_platform != 'win32'",
     "lightgbm>=4.6; sys_platform != 'win32'",
-    "xgboost>=2.0.0,<2.1.0; sys_platform != 'win32'"
+    "xgboost; sys_platform != 'win32'"
 ]
 spark = ["fugue[spark]>=0.9.4", "pyspark>=3.3", "lightgbm", "xgboost"]
 aws = ["fsspec[s3]"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,9 @@ ray = [
     "fugue[ray]>=0.9.4; sys_platform != 'win32'",
     "ray[data,train]>=2.56; sys_platform != 'win32'",
     "lightgbm>=4.6; sys_platform != 'win32'",
-    "xgboost; sys_platform != 'win32'"
+    # RayXGBForecast mixes RayForecastBase into XGBRegressor, which needs
+    # XGBModel.get_params' "parent has no get_params" fallback, added in 2.1.4
+    "xgboost>=2.1.4; sys_platform != 'win32'"
 ]
 spark = ["fugue[spark]>=0.9.4", "pyspark>=3.3", "lightgbm", "xgboost"]
 aws = ["fsspec[s3]"]

--- a/tests/distributed_ray/conftest.py
+++ b/tests/distributed_ray/conftest.py
@@ -3,8 +3,6 @@ import sys
 import pytest
 
 # Skip entire directory if Ray is not available or on Windows
-if sys.version_info >= (3, 14):
-    pytest.skip("Ray does not support Python 3.14+", allow_module_level=True)
 pytest.importorskip("ray", reason="Ray is required for distributed tests")
 # CI only runs these on linux, but they work locally on macOS; set
 # MLFORECAST_FORCE_RAY_TESTS=1 to run them there while developing.

--- a/tests/distributed_ray/conftest.py
+++ b/tests/distributed_ray/conftest.py
@@ -1,12 +1,17 @@
+import os
 import sys
 import pytest
 
 # Skip entire directory if Ray is not available or on Windows
 if sys.version_info >= (3, 14):
     pytest.skip("Ray does not support Python 3.14+", allow_module_level=True)
-pytest.importorskip('ray', reason="Ray is required for distributed tests")
-if sys.platform != "linux":
-    pytest.skip("Distributed interface is only supported on Linux", allow_module_level=True)
+pytest.importorskip("ray", reason="Ray is required for distributed tests")
+# CI only runs these on linux, but they work locally on macOS; set
+# MLFORECAST_FORCE_RAY_TESTS=1 to run them there while developing.
+if sys.platform != "linux" and os.environ.get("MLFORECAST_FORCE_RAY_TESTS") != "1":
+    pytest.skip(
+        "Distributed interface is only supported on Linux", allow_module_level=True
+    )
 
 import ray
 
@@ -19,7 +24,7 @@ def ray_session():
         num_cpus=2,
         ignore_reinit_error=True,
         include_dashboard=False,
-        _temp_dir="/tmp/ray"
+        _temp_dir="/tmp/ray",
     )
     yield
     # Shutdown Ray after all tests complete
@@ -32,4 +37,30 @@ def ray_test_cleanup():
     yield
     # Ensure any datasets are cleaned up between tests
     import gc
+
     gc.collect()
+    _reclaim_placement_groups()
+
+
+def _reclaim_placement_groups():
+    """Remove placement groups left behind by a failed training run.
+
+    A training failure can leak its placement group, which keeps holding the
+    cluster's CPUs. The next test's ``ray.data`` call would then block forever
+    rather than fail, which is how a one line dtype error turned into a 6 hour
+    CI job (see #713).
+    """
+    from ray._raylet import PlacementGroupID
+    from ray.util.placement_group import (
+        PlacementGroup,
+        placement_group_table,
+        remove_placement_group,
+    )
+
+    for pg_id, info in placement_group_table().items():
+        if info["state"] == "REMOVED":
+            continue
+        try:
+            remove_placement_group(PlacementGroup(PlacementGroupID.from_hex(pg_id)))
+        except Exception:  # noqa: BLE001 - best effort cleanup
+            pass

--- a/tests/distributed_ray/conftest.py
+++ b/tests/distributed_ray/conftest.py
@@ -32,21 +32,29 @@ def ray_session():
 @pytest.fixture(autouse=True)
 def ray_test_cleanup():
     """Clean up Ray resources after each test."""
+    from ray.util.placement_group import placement_group_table
+
+    # anything already there belongs to a wider scoped fixture, not to this test
+    before = set(placement_group_table())
     yield
     # Ensure any datasets are cleaned up between tests
     import gc
 
     gc.collect()
-    _reclaim_placement_groups()
+    _reclaim_placement_groups(keep=before)
 
 
-def _reclaim_placement_groups():
+def _reclaim_placement_groups(keep=()):
     """Remove placement groups left behind by a failed training run.
 
     A training failure can leak its placement group, which keeps holding the
     cluster's CPUs. The next test's ``ray.data`` call would then block forever
     rather than fail, which is how a one line dtype error turned into a 6 hour
     CI job (see #713).
+
+    ``keep`` holds the ids that were already around when the test started, so a
+    group a session or module scoped fixture legitimately holds isn't taken with
+    them.
     """
     from ray._raylet import PlacementGroupID
     from ray.util.placement_group import (
@@ -56,7 +64,7 @@ def _reclaim_placement_groups():
     )
 
     for pg_id, info in placement_group_table().items():
-        if info["state"] == "REMOVED":
+        if pg_id in keep or info["state"] == "REMOVED":
             continue
         try:
             remove_placement_group(PlacementGroup(PlacementGroupID.from_hex(pg_id)))

--- a/tests/distributed_ray/test_ray_combine_transforms.py
+++ b/tests/distributed_ray/test_ray_combine_transforms.py
@@ -13,20 +13,20 @@ from mlforecast.utils import generate_daily_series
 
 
 @pytest.mark.ray
-@pytest.mark.skipif(sys.version_info <= (3, 9), reason="Distributed tests are not supported on Python < 3.10")
+@pytest.mark.skipif(
+    sys.version_info <= (3, 9),
+    reason="Distributed tests are not supported on Python < 3.10",
+)
 def test_ray_combine_transforms():
     """Test Combine transform with Ray distributed forecast"""
     series = generate_daily_series(
-        n_series=20,
-        max_length=100,
-        static_as_categorical=False,
-        with_trend=True
+        n_series=20, max_length=100, static_as_categorical=False, with_trend=True
     )
 
     ray_dataset = ray.data.from_pandas(series)
     ray_dataset = ray_dataset.map_batches(
-        lambda batch: batch.assign(unique_id=batch['unique_id'].astype(str)),
-        batch_format="pandas"
+        lambda batch: batch.assign(unique_id=batch["unique_id"].astype(str)),
+        batch_format="pandas",
     )
 
     # Define lag transforms configuration
@@ -38,29 +38,26 @@ def test_ray_combine_transforms():
                 operator.sub,
             ),
             Combine(
-                RollingMean(window_size=7, min_samples=1),
-                ExpandingMean(),
-                operator.add
+                RollingMean(window_size=7, min_samples=1), ExpandingMean(), operator.add
             ),
-            RollingMean(window_size=7, min_samples=1)
+            RollingMean(window_size=7, min_samples=1),
         ]
     }
 
     # Create distributed MLForecast with Ray
     dmlf = DistributedMLForecast(
-        models=[RayLGBMForecast()],
+        models=[RayLGBMForecast(n_estimators=5)],
         freq="D",
         lag_transforms=lag_transforms_config,
     )
 
     # Test preprocessing with Ray creates expected features
     ray_transformed_df = dmlf.preprocess(
-        ray_dataset,
-        id_col='unique_id',
-        time_col='ds',
-        target_col='y'
+        ray_dataset, id_col="unique_id", time_col="ds", target_col="y"
     )
-    ray_result = ray_transformed_df.to_pandas().sort_values(["unique_id", "ds"], ignore_index = True)
+    ray_result = ray_transformed_df.to_pandas().sort_values(
+        ["unique_id", "ds"], ignore_index=True
+    )
 
     # Create local MLForecast for comparison (without model to avoid fitting)
     local_mlf = MLForecast(
@@ -70,22 +67,31 @@ def test_ray_combine_transforms():
     )
 
     # Preprocess with local version
-    local_result = local_mlf.preprocess(series).sort_values(["unique_id", "ds"], ignore_index = True)
+    local_result = local_mlf.preprocess(series).sort_values(
+        ["unique_id", "ds"], ignore_index=True
+    )
 
     # Compare feature columns (both should have the same features)
-    ray_feature_cols = [col for col in ray_result.columns if col.startswith(('lag', 'rolling', 'expanding'))]
-    local_feature_cols = [col for col in local_result.columns if col.startswith(('lag', 'rolling', 'expanding'))]
-    assert sorted(ray_feature_cols) == sorted(local_feature_cols), "Feature columns don't match"
+    ray_feature_cols = [
+        col
+        for col in ray_result.columns
+        if col.startswith(("lag", "rolling", "expanding"))
+    ]
+    local_feature_cols = [
+        col
+        for col in local_result.columns
+        if col.startswith(("lag", "rolling", "expanding"))
+    ]
+    assert sorted(ray_feature_cols) == sorted(local_feature_cols), (
+        "Feature columns don't match"
+    )
 
     assert not ray_result.empty
 
     # Compare the generated features (allowing for floating point differences)
     for col in ray_feature_cols:
         pd.testing.assert_series_equal(
-            ray_result[col],
-            local_result[col],
-            check_dtype=False,
-            atol=1e-6
+            ray_result[col], local_result[col], check_dtype=False, atol=1e-6
         )
 
     # Test fitting works with Ray

--- a/tests/distributed_ray/test_ray_combine_transforms.py
+++ b/tests/distributed_ray/test_ray_combine_transforms.py
@@ -1,5 +1,4 @@
 import operator
-import sys
 
 import pandas as pd
 import pytest
@@ -13,10 +12,6 @@ from mlforecast.utils import generate_daily_series
 
 
 @pytest.mark.ray
-@pytest.mark.skipif(
-    sys.version_info <= (3, 9),
-    reason="Distributed tests are not supported on Python < 3.10",
-)
 def test_ray_combine_transforms():
     """Test Combine transform with Ray distributed forecast"""
     series = generate_daily_series(

--- a/tests/distributed_ray/test_ray_forecast.py
+++ b/tests/distributed_ray/test_ray_forecast.py
@@ -16,14 +16,19 @@ warnings.simplefilter("ignore", FutureWarning)
 
 
 @pytest.mark.ray
-@pytest.mark.skipif(sys.version_info < (3, 10), reason="Distributed tests are not supported on Python < 3.10")
+@pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="Distributed tests are not supported on Python < 3.10",
+)
 @pytest.mark.parametrize(
     "model_class,model_kwargs",
     [
-        (RayLGBMForecast, {"verbosity": -1, "random_state": 0}),
-        (RayXGBForecast, {"random_state": 0}),
+        # these assert that predictions match across paths, not model quality,
+        # so a handful of trees is enough and keeps the run cheap
+        (RayLGBMForecast, {"verbosity": -1, "random_state": 0, "n_estimators": 5}),
+        (RayXGBForecast, {"random_state": 0, "n_estimators": 5}),
     ],
-    ids=["lightgbm", "xgboost"]
+    ids=["lightgbm", "xgboost"],
 )
 def test_ray_distributed_forecast(model_class, model_kwargs):
     series = generate_daily_series(
@@ -33,8 +38,8 @@ def test_ray_distributed_forecast(model_class, model_kwargs):
     # Create Ray dataset from pandas
     ray_dataset = ray.data.from_pandas(series)
     ray_dataset = ray_dataset.map_batches(
-        lambda batch: batch.assign(unique_id=batch['unique_id'].astype(str)),
-        batch_format="pandas"
+        lambda batch: batch.assign(unique_id=batch["unique_id"].astype(str)),
+        batch_format="pandas",
     )
 
     # test existing features provide the same result
@@ -53,17 +58,24 @@ def test_ray_distributed_forecast(model_class, model_kwargs):
         ray_dataset, static_features=[], dropna=False
     )
     fcst.fit(training_df_featured, static_features=[], dropna=False)
-    preds1 = fcst.predict(10).to_pandas().sort_values(["unique_id", "ds"], ignore_index = True)
-    fcst.save(f'/tmp/test_ray_forecast_model_{model_class.__name__}.pkl')
+    preds1 = (
+        fcst.predict(10).to_pandas().sort_values(["unique_id", "ds"], ignore_index=True)
+    )
+    fcst.save(f"/tmp/test_ray_forecast_model_{model_class.__name__}.pkl")
 
     # df without features
     fcst.preprocess(ray_dataset, static_features=[], dropna=False)
-    preds2 = fcst.predict(10).to_pandas().sort_values(["unique_id", "ds"], ignore_index = True)
+    preds2 = (
+        fcst.predict(10).to_pandas().sort_values(["unique_id", "ds"], ignore_index=True)
+    )
     pd.testing.assert_frame_equal(preds1, preds2)
 
 
 @pytest.mark.ray
-@pytest.mark.skipif(sys.version_info < (3, 10), reason="Distributed tests are not supported on Python < 3.10")
+@pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="Distributed tests are not supported on Python < 3.10",
+)
 def test_ray_distributed_forecast_with_x_df():
     """predict() with X_df as a Ray Dataset must give the same result as pandas X_df."""
     h = 7
@@ -76,7 +88,7 @@ def test_ray_distributed_forecast_with_x_df():
         batch_format="pandas",
     )
     fcst = DistributedMLForecast(
-        models=[RayLGBMForecast(verbosity=-1, random_state=0)],
+        models=[RayLGBMForecast(verbosity=-1, random_state=0, n_estimators=5)],
         freq="D",
         lags=[1, 2, 7],
         date_features=["dayofweek"],
@@ -84,7 +96,10 @@ def test_ray_distributed_forecast_with_x_df():
     fcst.fit(ray_series, static_features=[])
 
     last_dates = (
-        series.groupby("unique_id")["ds"].max().reset_index().rename(columns={"ds": "last_ds"})
+        series.groupby("unique_id")["ds"]
+        .max()
+        .reset_index()
+        .rename(columns={"ds": "last_ds"})
     )
     future_rows = []
     for _, row in last_dates.iterrows():
@@ -113,7 +128,10 @@ def test_ray_distributed_forecast_with_x_df():
 
 
 @pytest.mark.ray
-@pytest.mark.skipif(sys.version_info < (3, 10), reason="Distributed tests are not supported on Python < 3.10")
+@pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="Distributed tests are not supported on Python < 3.10",
+)
 def test_ray_weight_col_raises_not_implemented():
     """Ray engine must raise NotImplementedError when weight_col is passed to fit()."""
     series = generate_daily_series(5, min_length=50, max_length=50)

--- a/tests/distributed_ray/test_ray_forecast.py
+++ b/tests/distributed_ray/test_ray_forecast.py
@@ -31,9 +31,7 @@ warnings.simplefilter("ignore", FutureWarning)
     ids=["lightgbm", "xgboost"],
 )
 def test_ray_distributed_forecast(model_class, model_kwargs):
-    series = generate_daily_series(
-        100, equal_ends=True, min_length=500, max_length=1_000
-    )
+    series = generate_daily_series(20, equal_ends=True, min_length=100, max_length=200)
 
     # Create Ray dataset from pandas
     ray_dataset = ray.data.from_pandas(series)
@@ -49,7 +47,7 @@ def test_ray_distributed_forecast(model_class, model_kwargs):
         lags=[1, 2, 3, 4, 5, 6, 7],
         lag_transforms={
             1: [RollingMean(7), RollingMean(30), ExpandingMean()],
-            335: [RollingMean(30)],
+            20: [RollingMean(30)],
         },
         date_features=["dayofweek"],
     )

--- a/tests/distributed_ray/test_ray_forecast.py
+++ b/tests/distributed_ray/test_ray_forecast.py
@@ -1,4 +1,3 @@
-import sys
 import warnings
 
 import numpy as np
@@ -16,10 +15,6 @@ warnings.simplefilter("ignore", FutureWarning)
 
 
 @pytest.mark.ray
-@pytest.mark.skipif(
-    sys.version_info < (3, 10),
-    reason="Distributed tests are not supported on Python < 3.10",
-)
 @pytest.mark.parametrize(
     "model_class,model_kwargs",
     [
@@ -70,10 +65,6 @@ def test_ray_distributed_forecast(model_class, model_kwargs):
 
 
 @pytest.mark.ray
-@pytest.mark.skipif(
-    sys.version_info < (3, 10),
-    reason="Distributed tests are not supported on Python < 3.10",
-)
 def test_ray_distributed_forecast_with_x_df():
     """predict() with X_df as a Ray Dataset must give the same result as pandas X_df."""
     h = 7
@@ -126,10 +117,6 @@ def test_ray_distributed_forecast_with_x_df():
 
 
 @pytest.mark.ray
-@pytest.mark.skipif(
-    sys.version_info < (3, 10),
-    reason="Distributed tests are not supported on Python < 3.10",
-)
 def test_ray_weight_col_raises_not_implemented():
     """Ray engine must raise NotImplementedError when weight_col is passed to fit()."""
     series = generate_daily_series(5, min_length=50, max_length=50)

--- a/tests/distributed_ray/test_ray_models.py
+++ b/tests/distributed_ray/test_ray_models.py
@@ -1,3 +1,4 @@
+import pickle
 import sys
 
 import lightgbm as lgb
@@ -5,74 +6,89 @@ import numpy as np
 import pandas as pd
 import pytest
 import ray
+import xgboost as xgb
 from sklearn.base import clone
 
 from mlforecast.distributed.models.ray.lgb import RayLGBMForecast
 from mlforecast.distributed.models.ray.xgb import RayXGBForecast
 
+requires_py310 = pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="Distributed tests are not supported on Python < 3.10",
+)
+
 
 @pytest.mark.ray
 @pytest.mark.parametrize("model_cls", [RayLGBMForecast, RayXGBForecast])
 def test_clone_preserves_booster_params(model_cls):
-    """sklearn's introspection ignores **kwargs, so get_params is overridden.
+    """DistributedMLForecast._fit clones the model, so get_params has to be complete.
 
-    Without that override `clone` in DistributedMLForecast._fit would silently
-    drop every parameter the user passed.
+    sklearn's introspection reads the subclass' signature, which only names the
+    ray arguments, so the booster's parameters have to come from the library's
+    own get_params.
     """
-    model = model_cls(num_workers=2, random_state=0, learning_rate=0.05)
+    model = model_cls(num_workers=2, random_state=0, learning_rate=0.05, n_estimators=5)
     params = model.get_params()
+    assert params["num_workers"] == 2
     assert params["random_state"] == 0
     assert params["learning_rate"] == 0.05
-    assert params["num_workers"] == 2
+    assert params["n_estimators"] == 5
 
-    cloned = clone(model)
-    assert cloned.params == {"random_state": 0, "learning_rate": 0.05}
-    assert cloned.num_workers == 2
-
-
-@pytest.mark.ray
-def test_lgb_param_translation():
-    params, num_boost_round = RayLGBMForecast(
-        n_estimators=7, verbosity=-1, random_state=0
-    )._translate_params()
-    assert num_boost_round == 7
-    # lightgbm takes random_state as an alias of seed, so it's passed through
-    assert params == {"verbosity": -1, "random_state": 0, "objective": "regression"}
-
-
-@pytest.mark.ray
-def test_xgb_param_translation():
-    params, num_boost_round = RayXGBForecast(
-        n_estimators=7, random_state=0, max_depth=3
-    )._translate_params()
-    assert num_boost_round == 7
-    # the native API doesn't know random_state
-    assert params == {
-        "seed": 0,
-        "max_depth": 3,
-        "objective": "reg:squarederror",
-    }
+    cloned = clone(model).get_params()
+    assert cloned["num_workers"] == 2
+    assert cloned["random_state"] == 0
+    assert cloned["learning_rate"] == 0.05
+    assert cloned["n_estimators"] == 5
 
 
 @pytest.mark.ray
 def test_default_num_boost_round_matches_sklearn():
-    """The estimators defaulted to n_estimators=100; keep that."""
-    for model_cls in (RayLGBMForecast, RayXGBForecast):
-        _, num_boost_round = model_cls()._translate_params()
-        assert num_boost_round == 100
+    """The estimators defaulted to 100 rounds; keep that.
+
+    Each library resolves it its own way now: lightgbm reads `n_estimators`,
+    xgboost leaves it None and falls back to 100 in get_num_boosting_rounds.
+    """
+    assert RayLGBMForecast().get_params()["n_estimators"] == 100
+    assert RayXGBForecast().get_num_boosting_rounds() == 100
 
 
 @pytest.mark.ray
-@pytest.mark.skipif(
-    sys.version_info < (3, 10),
-    reason="Distributed tests are not supported on Python < 3.10",
-)
-def test_local_model_uses_the_trained_booster():
-    """model_ grafts the distributed booster onto a local estimator.
+@requires_py310
+def test_lgb_trains_on_the_full_dataset_across_workers():
+    """Every worker only sees its shard, so lightgbm needs its network params.
 
-    This is the fragile part of the lightgbm path (it copies private fitted
-    state, as lightgbm_ray did), so pin the estimator's predictions to the
-    booster's.
+    Without them each worker trains an independent model on 1/N of the data and
+    rank 0's is the one that gets checkpointed, with no error anywhere. The
+    feature is constant, so no split is possible and the prediction is exactly
+    the mean of whatever the model actually saw.
+    """
+    df = pd.DataFrame(
+        {"x": np.ones(200), "y": np.r_[np.zeros(100), np.full(100, 100.0)]}
+    )
+    model = RayLGBMForecast(num_workers=2, n_estimators=5, verbosity=-1, random_state=0)
+    model.fit(ray.data.from_pandas(df), target_col="y")
+
+    # 0.0 would mean rank 0 only ever saw the first shard
+    np.testing.assert_allclose(
+        model.model_.predict(pd.DataFrame({"x": [1.0]})), [50.0], atol=1e-6
+    )
+    # and each worker sizes its thread pool from its own CPU share rather than
+    # from every core on the box, as lightgbm_ray's _set_omp_num_threads did
+    assert model.model_.n_jobs == 1
+
+
+@pytest.mark.ray
+@requires_py310
+@pytest.mark.parametrize(
+    "model_cls,local_cls",
+    [(RayLGBMForecast, lgb.LGBMRegressor), (RayXGBForecast, xgb.XGBRegressor)],
+    ids=["lightgbm", "xgboost"],
+)
+def test_model_is_the_estimator_fitted_in_the_worker(model_cls, local_cls):
+    """model_ is the estimator the worker fitted, not one rebuilt from params.
+
+    Rebuilding it from the native params lost the user's arguments (n_estimators
+    came back as the default) and the booster's scores.
     """
     rng = np.random.default_rng(0)
     df = pd.DataFrame(
@@ -82,17 +98,67 @@ def test_local_model_uses_the_trained_booster():
             "y": rng.normal(size=200),
         }
     )
-    dataset = ray.data.from_pandas(df)
+    kwargs = {"verbosity": -1} if model_cls is RayLGBMForecast else {}
+    model = model_cls(random_state=0, n_estimators=5, **kwargs)
+    model.fit(ray.data.from_pandas(df), target_col="y")
 
-    model = RayLGBMForecast(verbosity=-1, random_state=0, n_estimators=5)
-    model.fit(dataset, target_col="y")
+    local = model.model_
+    assert isinstance(local, local_cls)
+    # the user's params survive the round trip
+    assert local.n_estimators == 5
+    assert local.random_state == 0
+    # and so do the fitted attributes
+    assert local.evals_result_
+    assert local.feature_importances_.shape == (2,)
 
-    assert isinstance(model.model_, lgb.LGBMRegressor)
     X = df[["lag1", "lag2"]].head(10)
-    np.testing.assert_allclose(
-        model.model_.predict(X), model.model_.booster_.predict(X)
-    )
-    assert model.model_.booster_.num_trees() == 5
+    booster = local.booster_ if model_cls is RayLGBMForecast else local.get_booster()
+    if model_cls is RayLGBMForecast:
+        np.testing.assert_allclose(local.predict(X), booster.predict(X))
+        assert booster.num_trees() == 5
+    else:
+        np.testing.assert_allclose(
+            local.predict(X), booster.predict(xgb.DMatrix(X)), rtol=1e-6
+        )
+
+
+@pytest.mark.ray
+@requires_py310
+def test_lgb_honors_param_aliases():
+    """The hand rolled translation dropped lightgbm's aliases; its own does not.
+
+    `objective` has five aliases, and the previous `setdefault("objective", ...)`
+    only checked the canonical name, so `application` was silently overridden
+    with `regression`. `num_iterations` has eleven, of which three were covered.
+    """
+    rng = np.random.default_rng(0)
+    df = pd.DataFrame({"x": rng.normal(size=100), "y": rng.random(size=100)})
+    model = RayLGBMForecast(application="poisson", num_iterations=7, verbosity=-1)
+    model.fit(ray.data.from_pandas(df), target_col="y")
+
+    assert model.model_.objective_ == "poisson"
+    assert model.model_.booster_.num_trees() == 7
+
+
+@pytest.mark.ray
+@requires_py310
+def test_xgb_keeps_random_state_and_drops_the_ray_callback():
+    """xgb.train knows `random_state`, so there was never a `seed` to translate to.
+
+    xgboost also stores callbacks as a parameter, so the ray reporting callback
+    would otherwise ride back to the driver and into whatever the user pickles
+    through DistributedMLForecast.save.
+    """
+    rng = np.random.default_rng(0)
+    df = pd.DataFrame({"x": rng.normal(size=100), "y": rng.random(size=100)})
+    model = RayXGBForecast(random_state=0, n_estimators=5)
+    model.fit(ray.data.from_pandas(df), target_col="y")
+
+    params = model.model_.get_params()
+    assert params["random_state"] == 0
+    assert "seed" not in params
+    assert params["callbacks"] is None
+    pickle.loads(pickle.dumps(model.model_))
 
 
 @pytest.mark.ray

--- a/tests/distributed_ray/test_ray_models.py
+++ b/tests/distributed_ray/test_ray_models.py
@@ -1,0 +1,111 @@
+import sys
+
+import lightgbm as lgb
+import numpy as np
+import pandas as pd
+import pytest
+import ray
+from sklearn.base import clone
+
+from mlforecast.distributed.models.ray.lgb import RayLGBMForecast
+from mlforecast.distributed.models.ray.xgb import RayXGBForecast
+
+
+@pytest.mark.ray
+@pytest.mark.parametrize("model_cls", [RayLGBMForecast, RayXGBForecast])
+def test_clone_preserves_booster_params(model_cls):
+    """sklearn's introspection ignores **kwargs, so get_params is overridden.
+
+    Without that override `clone` in DistributedMLForecast._fit would silently
+    drop every parameter the user passed.
+    """
+    model = model_cls(num_workers=2, random_state=0, learning_rate=0.05)
+    params = model.get_params()
+    assert params["random_state"] == 0
+    assert params["learning_rate"] == 0.05
+    assert params["num_workers"] == 2
+
+    cloned = clone(model)
+    assert cloned.params == {"random_state": 0, "learning_rate": 0.05}
+    assert cloned.num_workers == 2
+
+
+@pytest.mark.ray
+def test_lgb_param_translation():
+    params, num_boost_round = RayLGBMForecast(
+        n_estimators=7, verbosity=-1, random_state=0
+    )._translate_params()
+    assert num_boost_round == 7
+    # lightgbm takes random_state as an alias of seed, so it's passed through
+    assert params == {"verbosity": -1, "random_state": 0, "objective": "regression"}
+
+
+@pytest.mark.ray
+def test_xgb_param_translation():
+    params, num_boost_round = RayXGBForecast(
+        n_estimators=7, random_state=0, max_depth=3
+    )._translate_params()
+    assert num_boost_round == 7
+    # the native API doesn't know random_state
+    assert params == {
+        "seed": 0,
+        "max_depth": 3,
+        "objective": "reg:squarederror",
+    }
+
+
+@pytest.mark.ray
+def test_default_num_boost_round_matches_sklearn():
+    """The estimators defaulted to n_estimators=100; keep that."""
+    for model_cls in (RayLGBMForecast, RayXGBForecast):
+        _, num_boost_round = model_cls()._translate_params()
+        assert num_boost_round == 100
+
+
+@pytest.mark.ray
+@pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="Distributed tests are not supported on Python < 3.10",
+)
+def test_local_model_uses_the_trained_booster():
+    """model_ grafts the distributed booster onto a local estimator.
+
+    This is the fragile part of the lightgbm path (it copies private fitted
+    state, as lightgbm_ray did), so pin the estimator's predictions to the
+    booster's.
+    """
+    rng = np.random.default_rng(0)
+    df = pd.DataFrame(
+        {
+            "lag1": rng.normal(size=200),
+            "lag2": rng.normal(size=200),
+            "y": rng.normal(size=200),
+        }
+    )
+    dataset = ray.data.from_pandas(df)
+
+    model = RayLGBMForecast(verbosity=-1, random_state=0, n_estimators=5)
+    model.fit(dataset, target_col="y")
+
+    assert isinstance(model.model_, lgb.LGBMRegressor)
+    X = df[["lag1", "lag2"]].head(10)
+    np.testing.assert_allclose(
+        model.model_.predict(X), model.model_.booster_.predict(X)
+    )
+    assert model.model_.booster_.num_trees() == 5
+
+
+@pytest.mark.ray
+def test_reclaim_placement_groups_frees_a_leaked_group():
+    """The conftest safety net that keeps a leak from hanging the next test."""
+    from ray.util.placement_group import placement_group, placement_group_table
+
+    from .conftest import _reclaim_placement_groups
+
+    pg = placement_group([{"CPU": 1}])
+    ray.get(pg.ready())
+    assert any(info["state"] == "CREATED" for info in placement_group_table().values())
+
+    _reclaim_placement_groups()
+
+    assert all(info["state"] == "REMOVED" for info in placement_group_table().values())

--- a/tests/distributed_ray/test_ray_models.py
+++ b/tests/distributed_ray/test_ray_models.py
@@ -1,5 +1,5 @@
 import pickle
-import sys
+from pathlib import Path
 
 import lightgbm as lgb
 import numpy as np
@@ -11,11 +11,6 @@ from sklearn.base import clone
 
 from mlforecast.distributed.models.ray.lgb import RayLGBMForecast
 from mlforecast.distributed.models.ray.xgb import RayXGBForecast
-
-requires_py310 = pytest.mark.skipif(
-    sys.version_info < (3, 10),
-    reason="Distributed tests are not supported on Python < 3.10",
-)
 
 
 @pytest.mark.ray
@@ -53,7 +48,6 @@ def test_default_num_boost_round_matches_sklearn():
 
 
 @pytest.mark.ray
-@requires_py310
 def test_lgb_trains_on_the_full_dataset_across_workers():
     """Every worker only sees its shard, so lightgbm needs its network params.
 
@@ -65,20 +59,20 @@ def test_lgb_trains_on_the_full_dataset_across_workers():
     df = pd.DataFrame(
         {"x": np.ones(200), "y": np.r_[np.zeros(100), np.full(100, 100.0)]}
     )
-    model = RayLGBMForecast(num_workers=2, n_estimators=5, verbosity=-1, random_state=0)
+    model = RayLGBMForecast(
+        num_workers=2, n_estimators=5, verbosity=-1, random_state=0, n_jobs=2
+    )
     model.fit(ray.data.from_pandas(df), target_col="y")
 
     # 0.0 would mean rank 0 only ever saw the first shard
     np.testing.assert_allclose(
         model.model_.predict(pd.DataFrame({"x": [1.0]})), [50.0], atol=1e-6
     )
-    # and each worker sizes its thread pool from its own CPU share rather than
-    # from every core on the box, as lightgbm_ray's _set_omp_num_threads did
-    assert model.model_.n_jobs == 1
+    # the clamp is the worker's business; model_ carries what was asked for
+    assert model.model_.n_jobs == 2
 
 
 @pytest.mark.ray
-@requires_py310
 @pytest.mark.parametrize(
     "model_cls,local_cls",
     [(RayLGBMForecast, lgb.LGBMRegressor), (RayXGBForecast, xgb.XGBRegressor)],
@@ -123,7 +117,6 @@ def test_model_is_the_estimator_fitted_in_the_worker(model_cls, local_cls):
 
 
 @pytest.mark.ray
-@requires_py310
 def test_lgb_honors_param_aliases():
     """The hand rolled translation dropped lightgbm's aliases; its own does not.
 
@@ -141,7 +134,6 @@ def test_lgb_honors_param_aliases():
 
 
 @pytest.mark.ray
-@requires_py310
 def test_xgb_keeps_random_state_and_drops_the_ray_callback():
     """xgb.train knows `random_state`, so there was never a `seed` to translate to.
 
@@ -175,3 +167,60 @@ def test_reclaim_placement_groups_frees_a_leaked_group():
     _reclaim_placement_groups()
 
     assert all(info["state"] == "REMOVED" for info in placement_group_table().values())
+
+
+@pytest.mark.ray
+def test_reclaim_placement_groups_keeps_a_pre_existing_group():
+    """A group a fixture legitimately holds across tests has to survive the cleanup."""
+    from ray.util.placement_group import (
+        placement_group,
+        placement_group_table,
+        remove_placement_group,
+    )
+
+    from .conftest import _reclaim_placement_groups
+
+    pg = placement_group([{"CPU": 1}])
+    ray.get(pg.ready())
+
+    _reclaim_placement_groups(keep={pg.id.hex()})
+
+    assert placement_group_table()[pg.id.hex()]["state"] == "CREATED"
+    remove_placement_group(pg)
+
+
+@pytest.mark.ray
+def test_workers_get_a_share_of_the_cluster_cpus():
+    """ScalingConfig assigns one CPU per worker, which would train single threaded.
+
+    `xgboost_ray._autodetect_resources` split the cluster's CPUs across its
+    actors instead, so `n_jobs` alone could never raise the thread count back up.
+    """
+    cpus = int(ray.cluster_resources()["CPU"])
+    assert RayLGBMForecast()._resources_per_worker() == {"CPU": cpus}
+    assert RayLGBMForecast(num_workers=2)._resources_per_worker() == {"CPU": cpus // 2}
+    # an explicit value wins
+    assert RayXGBForecast(resources_per_worker={"CPU": 1})._resources_per_worker() == {
+        "CPU": 1
+    }
+
+
+@pytest.mark.ray
+def test_fit_does_not_write_to_the_default_storage_path(tmp_path):
+    """The default RunConfig would grow ~/ray_results by a run per model per fit."""
+    default_storage = Path("~/ray_results").expanduser()
+    before = set(default_storage.iterdir()) if default_storage.exists() else set()
+
+    rng = np.random.default_rng(0)
+    df = pd.DataFrame({"x": rng.normal(size=100), "y": rng.random(size=100)})
+    dataset = ray.data.from_pandas(df)
+    RayLGBMForecast(n_estimators=2, verbosity=-1).fit(dataset, target_col="y")
+
+    after = set(default_storage.iterdir()) if default_storage.exists() else set()
+    assert after == before
+
+    # and an explicit path is honoured
+    RayLGBMForecast(n_estimators=2, verbosity=-1, storage_path=str(tmp_path)).fit(
+        dataset, target_col="y"
+    )
+    assert any(tmp_path.iterdir())

--- a/tests/distributed_ray/test_ray_models.py
+++ b/tests/distributed_ray/test_ray_models.py
@@ -196,6 +196,7 @@ def test_workers_get_a_share_of_the_cluster_cpus():
     `xgboost_ray._autodetect_resources` split the cluster's CPUs across its
     actors instead, so `n_jobs` alone could never raise the thread count back up.
     """
+    # the test cluster is a single node, so its CPUs are also the smallest node's
     cpus = int(ray.cluster_resources()["CPU"])
     assert RayLGBMForecast()._resources_per_worker() == {"CPU": cpus}
     assert RayLGBMForecast(num_workers=2)._resources_per_worker() == {"CPU": cpus // 2}
@@ -203,6 +204,85 @@ def test_workers_get_a_share_of_the_cluster_cpus():
     assert RayXGBForecast(resources_per_worker={"CPU": 1})._resources_per_worker() == {
         "CPU": 1
     }
+
+
+@pytest.mark.ray
+@pytest.mark.timeout(300, method="thread")
+def test_fit_executes_a_pending_dataset_before_taking_the_cpus():
+    """A dataset with work left to do can't run once the workers hold the CPUs.
+
+    Ray train hands `ScalingConfig.total_resources` to ray data as
+    `exclude_resources`, so the default share (every CPU on the node) leaves data
+    a budget of zero and `fit` blocks forever rather than failing.
+
+    The timeout is what turns a regression here into a failure instead of a hung
+    CI job, and it has to be the thread method: pytest-timeout's default raises
+    from a SIGALRM handler, which never runs while the main thread sits in ray's
+    C++ core worker. Measured, a plain `--timeout=90` didn't fire in 21 minutes.
+    """
+    df = pd.DataFrame(
+        {"x": np.ones(200), "y": np.r_[np.zeros(100), np.full(100, 100.0)]}
+    )
+    # map_batches leaves the dataset pending, unlike a bare from_pandas
+    dataset = ray.data.from_pandas(df).map_batches(lambda b: b, batch_size=50)
+    model = RayLGBMForecast(n_estimators=5, verbosity=-1)
+    # the whole cluster, so ray data would be left with nothing
+    assert model._resources_per_worker() == {"CPU": int(ray.cluster_resources()["CPU"])}
+    model.fit(dataset, target_col="y")
+
+    np.testing.assert_allclose(
+        model.model_.predict(pd.DataFrame({"x": [1.0]})), [50.0], atol=1e-6
+    )
+
+
+@pytest.mark.ray
+@pytest.mark.parametrize(
+    "nodes,num_workers,expected",
+    [
+        # the cluster has 4 CPUs but neither node can fit a 4 CPU bundle
+        ([2.0, 2.0], 1, 2),
+        # heterogeneous: 8 // 2 = 4, which only the larger node could take
+        ([1.0, 7.0], 2, 1),
+        # the node bound is what binds here, not the split
+        ([8.0, 8.0], 1, 8),
+    ],
+    ids=["even", "heterogeneous", "bounded-by-node"],
+)
+def test_worker_share_fits_on_a_single_node(monkeypatch, nodes, num_workers, expected):
+    """A placement group bundle has to be schedulable on one node.
+
+    Sizing it from `cluster_resources` alone asks for more than any single node
+    has, which the autoscaler can't fulfill, so `fit` hangs instead of failing.
+    """
+    node_table = [{"Alive": True, "Resources": {"CPU": cpus}} for cpus in nodes]
+    # a stopped 1 CPU node shouldn't pull the bound down to 1
+    node_table.append({"Alive": False, "Resources": {"CPU": 1.0}})
+    monkeypatch.setattr(ray, "cluster_resources", lambda: {"CPU": sum(nodes)})
+    monkeypatch.setattr(ray, "nodes", lambda: node_table)
+    assert RayLGBMForecast(num_workers=num_workers)._resources_per_worker() == {
+        "CPU": expected
+    }
+
+
+@pytest.mark.ray
+def test_worker_n_jobs_is_capped_by_the_assigned_cpus():
+    """The thread pool is sized from the CPUs the train worker was actually given.
+
+    `model_` carries the requested `n_jobs` rather than the clamp, so asserting on
+    it after a fit doesn't exercise this.
+    """
+    from mlforecast.distributed.models.ray._base import worker_n_jobs
+
+    @ray.remote
+    def assigned(requested):
+        return worker_n_jobs(requested)
+
+    # the session fixture starts the cluster with 2 CPUs
+    assert ray.get(assigned.options(num_cpus=2).remote(8)) == 2
+    # unset falls back to the whole share
+    assert ray.get(assigned.options(num_cpus=2).remote(None)) == 2
+    # a smaller explicit value is honoured
+    assert ray.get(assigned.options(num_cpus=2).remote(1)) == 1
 
 
 @pytest.mark.ray

--- a/uv.lock
+++ b/uv.lock
@@ -689,7 +689,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -770,7 +770,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -1240,7 +1240,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1529,10 +1529,10 @@ dask = [
     { name = "pyarrow" },
 ]
 ray = [
-    { name = "duckdb" },
-    { name = "pandas" },
-    { name = "pyarrow" },
-    { name = "ray", extra = ["data"] },
+    { name = "duckdb", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "pandas", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "pyarrow", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "ray", extra = ["data"], marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
 ]
 spark = [
     { name = "pyspark" },
@@ -1794,6 +1794,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/32/6a/33d1702184d94106d3cdd7bfb788e19723206fce152e303473ca3b946c7b/greenlet-3.3.0-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:6f8496d434d5cb2dce025773ba5597f71f5410ae499d5dd9533e0653258cdb3d", size = 273658, upload-time = "2025-12-04T14:23:37.494Z" },
     { url = "https://files.pythonhosted.org/packages/d6/b7/2b5805bbf1907c26e434f4e448cd8b696a0b71725204fa21a211ff0c04a7/greenlet-3.3.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b96dc7eef78fd404e022e165ec55327f935b9b52ff355b067eb4a0267fc1cffb", size = 574810, upload-time = "2025-12-04T14:50:04.154Z" },
     { url = "https://files.pythonhosted.org/packages/94/38/343242ec12eddf3d8458c73f555c084359883d4ddc674240d9e61ec51fd6/greenlet-3.3.0-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:73631cd5cccbcfe63e3f9492aaa664d278fda0ce5c3d43aeda8e77317e38efbd", size = 586248, upload-time = "2025-12-04T14:57:39.35Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/d0/0ae86792fb212e4384041e0ef8e7bc66f59a54912ce407d26a966ed2914d/greenlet-3.3.0-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b299a0cb979f5d7197442dccc3aee67fce53500cd88951b7e6c35575701c980b", size = 597403, upload-time = "2025-12-04T15:07:10.831Z" },
     { url = "https://files.pythonhosted.org/packages/b6/a8/15d0aa26c0036a15d2659175af00954aaaa5d0d66ba538345bd88013b4d7/greenlet-3.3.0-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7dee147740789a4632cace364816046e43310b59ff8fb79833ab043aefa72fd5", size = 586910, upload-time = "2025-12-04T14:25:59.705Z" },
     { url = "https://files.pythonhosted.org/packages/e1/9b/68d5e3b7ccaba3907e5532cf8b9bf16f9ef5056a008f195a367db0ff32db/greenlet-3.3.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:39b28e339fc3c348427560494e28d8a6f3561c8d2bcf7d706e1c624ed8d822b9", size = 1547206, upload-time = "2025-12-04T15:04:21.027Z" },
     { url = "https://files.pythonhosted.org/packages/66/bd/e3086ccedc61e49f91e2cfb5ffad9d8d62e5dc85e512a6200f096875b60c/greenlet-3.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b3c374782c2935cc63b2a27ba8708471de4ad1abaa862ffdb1ef45a643ddbb7d", size = 1613359, upload-time = "2025-12-04T14:27:26.548Z" },
@@ -1801,6 +1802,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/cb/48e964c452ca2b92175a9b2dca037a553036cb053ba69e284650ce755f13/greenlet-3.3.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:e29f3018580e8412d6aaf5641bb7745d38c85228dacf51a73bd4e26ddf2a6a8e", size = 274908, upload-time = "2025-12-04T14:23:26.435Z" },
     { url = "https://files.pythonhosted.org/packages/28/da/38d7bff4d0277b594ec557f479d65272a893f1f2a716cad91efeb8680953/greenlet-3.3.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a687205fb22794e838f947e2194c0566d3812966b41c78709554aa883183fb62", size = 577113, upload-time = "2025-12-04T14:50:05.493Z" },
     { url = "https://files.pythonhosted.org/packages/3c/f2/89c5eb0faddc3ff014f1c04467d67dee0d1d334ab81fadbf3744847f8a8a/greenlet-3.3.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4243050a88ba61842186cb9e63c7dfa677ec146160b0efd73b855a3d9c7fcf32", size = 590338, upload-time = "2025-12-04T14:57:41.136Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d7/db0a5085035d05134f8c089643da2b44cc9b80647c39e93129c5ef170d8f/greenlet-3.3.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:670d0f94cd302d81796e37299bcd04b95d62403883b24225c6b5271466612f45", size = 601098, upload-time = "2025-12-04T15:07:11.898Z" },
     { url = "https://files.pythonhosted.org/packages/dc/a6/e959a127b630a58e23529972dbc868c107f9d583b5a9f878fb858c46bc1a/greenlet-3.3.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6cb3a8ec3db4a3b0eb8a3c25436c2d49e3505821802074969db017b87bc6a948", size = 590206, upload-time = "2025-12-04T14:26:01.254Z" },
     { url = "https://files.pythonhosted.org/packages/48/60/29035719feb91798693023608447283b266b12efc576ed013dd9442364bb/greenlet-3.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2de5a0b09eab81fc6a382791b995b1ccf2b172a9fec934747a7a23d2ff291794", size = 1550668, upload-time = "2025-12-04T15:04:22.439Z" },
     { url = "https://files.pythonhosted.org/packages/0a/5f/783a23754b691bfa86bd72c3033aa107490deac9b2ef190837b860996c9f/greenlet-3.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4449a736606bd30f27f8e1ff4678ee193bc47f6ca810d705981cfffd6ce0d8c5", size = 1615483, upload-time = "2025-12-04T14:27:28.083Z" },
@@ -1808,6 +1810,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/0a/a3871375c7b9727edaeeea994bfff7c63ff7804c9829c19309ba2e058807/greenlet-3.3.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:b01548f6e0b9e9784a2c99c5651e5dc89ffcbe870bc5fb2e5ef864e9cc6b5dcb", size = 276379, upload-time = "2025-12-04T14:23:30.498Z" },
     { url = "https://files.pythonhosted.org/packages/43/ab/7ebfe34dce8b87be0d11dae91acbf76f7b8246bf9d6b319c741f99fa59c6/greenlet-3.3.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:349345b770dc88f81506c6861d22a6ccd422207829d2c854ae2af8025af303e3", size = 597294, upload-time = "2025-12-04T14:50:06.847Z" },
     { url = "https://files.pythonhosted.org/packages/a4/39/f1c8da50024feecd0793dbd5e08f526809b8ab5609224a2da40aad3a7641/greenlet-3.3.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e8e18ed6995e9e2c0b4ed264d2cf89260ab3ac7e13555b8032b25a74c6d18655", size = 607742, upload-time = "2025-12-04T14:57:42.349Z" },
+    { url = "https://files.pythonhosted.org/packages/77/cb/43692bcd5f7a0da6ec0ec6d58ee7cddb606d055ce94a62ac9b1aa481e969/greenlet-3.3.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c024b1e5696626890038e34f76140ed1daf858e37496d33f2af57f06189e70d7", size = 622297, upload-time = "2025-12-04T15:07:13.552Z" },
     { url = "https://files.pythonhosted.org/packages/75/b0/6bde0b1011a60782108c01de5913c588cf51a839174538d266de15e4bf4d/greenlet-3.3.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:047ab3df20ede6a57c35c14bf5200fcf04039d50f908270d3f9a7a82064f543b", size = 609885, upload-time = "2025-12-04T14:26:02.368Z" },
     { url = "https://files.pythonhosted.org/packages/49/0e/49b46ac39f931f59f987b7cd9f34bfec8ef81d2a1e6e00682f55be5de9f4/greenlet-3.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2d9ad37fc657b1102ec880e637cccf20191581f75c64087a549e66c57e1ceb53", size = 1567424, upload-time = "2025-12-04T15:04:23.757Z" },
     { url = "https://files.pythonhosted.org/packages/05/f5/49a9ac2dff7f10091935def9165c90236d8f175afb27cbed38fb1d61ab6b/greenlet-3.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:83cd0e36932e0e7f36a64b732a6f60c2fc2df28c351bae79fbaf4f8092fe7614", size = 1636017, upload-time = "2025-12-04T14:27:29.688Z" },
@@ -1815,6 +1818,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/02/2f/28592176381b9ab2cafa12829ba7b472d177f3acc35d8fbcf3673d966fff/greenlet-3.3.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:a1e41a81c7e2825822f4e068c48cb2196002362619e2d70b148f20a831c00739", size = 275140, upload-time = "2025-12-04T14:23:01.282Z" },
     { url = "https://files.pythonhosted.org/packages/2c/80/fbe937bf81e9fca98c981fe499e59a3f45df2a04da0baa5c2be0dca0d329/greenlet-3.3.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9f515a47d02da4d30caaa85b69474cec77b7929b2e936ff7fb853d42f4bf8808", size = 599219, upload-time = "2025-12-04T14:50:08.309Z" },
     { url = "https://files.pythonhosted.org/packages/c2/ff/7c985128f0514271b8268476af89aee6866df5eec04ac17dcfbc676213df/greenlet-3.3.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7d2d9fd66bfadf230b385fdc90426fcd6eb64db54b40c495b72ac0feb5766c54", size = 610211, upload-time = "2025-12-04T14:57:43.968Z" },
+    { url = "https://files.pythonhosted.org/packages/79/07/c47a82d881319ec18a4510bb30463ed6891f2ad2c1901ed5ec23d3de351f/greenlet-3.3.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:30a6e28487a790417d036088b3bcb3f3ac7d8babaa7d0139edbaddebf3af9492", size = 624311, upload-time = "2025-12-04T15:07:14.697Z" },
     { url = "https://files.pythonhosted.org/packages/fd/8e/424b8c6e78bd9837d14ff7df01a9829fc883ba2ab4ea787d4f848435f23f/greenlet-3.3.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:087ea5e004437321508a8d6f20efc4cfec5e3c30118e1417ea96ed1d93950527", size = 612833, upload-time = "2025-12-04T14:26:03.669Z" },
     { url = "https://files.pythonhosted.org/packages/b5/ba/56699ff9b7c76ca12f1cdc27a886d0f81f2189c3455ff9f65246780f713d/greenlet-3.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ab97cf74045343f6c60a39913fa59710e4bd26a536ce7ab2397adf8b27e67c39", size = 1567256, upload-time = "2025-12-04T15:04:25.276Z" },
     { url = "https://files.pythonhosted.org/packages/1e/37/f31136132967982d698c71a281a8901daf1a8fbab935dce7c0cf15f942cc/greenlet-3.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5375d2e23184629112ca1ea89a53389dddbffcf417dad40125713d88eb5f96e8", size = 1636483, upload-time = "2025-12-04T14:27:30.804Z" },
@@ -1822,6 +1826,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/7c/f0a6d0ede2c7bf092d00bc83ad5bafb7e6ec9b4aab2fbdfa6f134dc73327/greenlet-3.3.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:60c2ef0f578afb3c8d92ea07ad327f9a062547137afe91f38408f08aacab667f", size = 275671, upload-time = "2025-12-04T14:23:05.267Z" },
     { url = "https://files.pythonhosted.org/packages/44/06/dac639ae1a50f5969d82d2e3dd9767d30d6dbdbab0e1a54010c8fe90263c/greenlet-3.3.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a5d554d0712ba1de0a6c94c640f7aeba3f85b3a6e1f2899c11c2c0428da9365", size = 646360, upload-time = "2025-12-04T14:50:10.026Z" },
     { url = "https://files.pythonhosted.org/packages/e0/94/0fb76fe6c5369fba9bf98529ada6f4c3a1adf19e406a47332245ef0eb357/greenlet-3.3.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3a898b1e9c5f7307ebbde4102908e6cbfcb9ea16284a3abe15cab996bee8b9b3", size = 658160, upload-time = "2025-12-04T14:57:45.41Z" },
+    { url = "https://files.pythonhosted.org/packages/93/79/d2c70cae6e823fac36c3bbc9077962105052b7ef81db2f01ec3b9bf17e2b/greenlet-3.3.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:dcd2bdbd444ff340e8d6bdf54d2f206ccddbb3ccfdcd3c25bf4afaa7b8f0cf45", size = 671388, upload-time = "2025-12-04T15:07:15.789Z" },
     { url = "https://files.pythonhosted.org/packages/b8/14/bab308fc2c1b5228c3224ec2bf928ce2e4d21d8046c161e44a2012b5203e/greenlet-3.3.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5773edda4dc00e173820722711d043799d3adb4f01731f40619e07ea2750b955", size = 660166, upload-time = "2025-12-04T14:26:05.099Z" },
     { url = "https://files.pythonhosted.org/packages/4b/d2/91465d39164eaa0085177f61983d80ffe746c5a1860f009811d498e7259c/greenlet-3.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ac0549373982b36d5fd5d30beb8a7a33ee541ff98d2b502714a09f1169f31b55", size = 1615193, upload-time = "2025-12-04T15:04:27.041Z" },
     { url = "https://files.pythonhosted.org/packages/42/1b/83d110a37044b92423084d52d5d5a3b3a73cafb51b547e6d7366ff62eff1/greenlet-3.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d198d2d977460358c3b3a4dc844f875d1adb33817f0613f663a656f463764ccc", size = 1683653, upload-time = "2025-12-04T14:27:32.366Z" },
@@ -1829,6 +1834,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/66/bd6317bc5932accf351fc19f177ffba53712a202f9df10587da8df257c7e/greenlet-3.3.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d6ed6f85fae6cdfdb9ce04c9bf7a08d666cfcfb914e7d006f44f840b46741931", size = 282638, upload-time = "2025-12-04T14:25:20.941Z" },
     { url = "https://files.pythonhosted.org/packages/30/cf/cc81cb030b40e738d6e69502ccbd0dd1bced0588e958f9e757945de24404/greenlet-3.3.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9125050fcf24554e69c4cacb086b87b3b55dc395a8b3ebe6487b045b2614388", size = 651145, upload-time = "2025-12-04T14:50:11.039Z" },
     { url = "https://files.pythonhosted.org/packages/9c/ea/1020037b5ecfe95ca7df8d8549959baceb8186031da83d5ecceff8b08cd2/greenlet-3.3.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:87e63ccfa13c0a0f6234ed0add552af24cc67dd886731f2261e46e241608bee3", size = 654236, upload-time = "2025-12-04T14:57:47.007Z" },
+    { url = "https://files.pythonhosted.org/packages/69/cc/1e4bae2e45ca2fa55299f4e85854606a78ecc37fead20d69322f96000504/greenlet-3.3.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2662433acbca297c9153a4023fe2161c8dcfdcc91f10433171cf7e7d94ba2221", size = 662506, upload-time = "2025-12-04T15:07:16.906Z" },
     { url = "https://files.pythonhosted.org/packages/57/b9/f8025d71a6085c441a7eaff0fd928bbb275a6633773667023d19179fe815/greenlet-3.3.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3c6e9b9c1527a78520357de498b0e709fb9e2f49c3a513afd5a249007261911b", size = 653783, upload-time = "2025-12-04T14:26:06.225Z" },
     { url = "https://files.pythonhosted.org/packages/f6/c7/876a8c7a7485d5d6b5c6821201d542ef28be645aa024cfe1145b35c120c1/greenlet-3.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:286d093f95ec98fdd92fcb955003b8a3d054b4e2cab3e2707a5039e7b50520fd", size = 1614857, upload-time = "2025-12-04T15:04:28.484Z" },
     { url = "https://files.pythonhosted.org/packages/4f/dc/041be1dff9f23dac5f48a43323cd0789cb798342011c19a248d9c9335536/greenlet-3.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c10513330af5b8ae16f023e8ddbfb486ab355d04467c4679c5cfe4659975dd9", size = 1676034, upload-time = "2025-12-04T14:27:33.531Z" },
@@ -1952,7 +1958,7 @@ name = "gunicorn"
 version = "23.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "packaging" },
+    { name = "packaging", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/34/72/9614c465dc206155d93eff0ca20d42e1e35afc533971379482de953521a4/gunicorn-23.0.0.tar.gz", hash = "sha256:f014447a0101dc57e294f6c18ca6b40227a4c90e9bdb586042628030cba004ec", size = 375031, upload-time = "2024-08-10T20:25:27.378Z" }
 wheels = [
@@ -2106,10 +2112,10 @@ name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs" },
-    { name = "jsonschema-specifications" },
-    { name = "referencing" },
-    { name = "rpds-py" },
+    { name = "attrs", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "jsonschema-specifications", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "referencing", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "rpds-py", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
 wheels = [
@@ -2121,7 +2127,7 @@ name = "jsonschema-specifications"
 version = "2025.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "referencing" },
+    { name = "referencing", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
@@ -2335,20 +2341,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/64/41/4fbde2c3d29e25ee7c41d87df2f2e5eda65b431ee154d4d462c31041846c/lightgbm-4.6.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4d68712bbd2b57a0b14390cbf9376c1d5ed773fa2e71e099cac588703b590336", size = 3454567, upload-time = "2025-02-15T04:02:56.443Z" },
     { url = "https://files.pythonhosted.org/packages/42/86/dabda8fbcb1b00bcfb0003c3776e8ade1aa7b413dff0a2c08f457dace22f/lightgbm-4.6.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:cb19b5afea55b5b61cbb2131095f50538bd608a00655f23ad5d25ae3e3bf1c8d", size = 3569831, upload-time = "2025-02-15T04:02:58.925Z" },
     { url = "https://files.pythonhosted.org/packages/5e/23/f8b28ca248bb629b9e08f877dd2965d1994e1674a03d67cd10c5246da248/lightgbm-4.6.0-py3-none-win_amd64.whl", hash = "sha256:37089ee95664b6550a7189d887dbf098e3eadab03537e411f52c63c121e3ba4b", size = 1451509, upload-time = "2025-02-15T04:03:01.515Z" },
-]
-
-[[package]]
-name = "lightgbm-ray"
-version = "0.1.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "lightgbm" },
-    { name = "packaging" },
-    { name = "xgboost-ray" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/44/b1/a06f923709a887465108da636b442194dabd414761d54fb9da51184b4694/lightgbm_ray-0.1.9.tar.gz", hash = "sha256:ac47f10455c069393359a18e41b646185ce7b9a762c9c41b17bf2fbaa6b934dc", size = 57348, upload-time = "2023-08-24T16:37:04.023Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/01/0412ae1292f18b895d9bff1c395bc389f27de48dc95330a0543eb37299b3/lightgbm_ray-0.1.9-py3-none-any.whl", hash = "sha256:1e6246b022015312c218a38d3d32d24c018c3795ed70c586e435f3e663372b66", size = 73817, upload-time = "2023-08-24T16:37:00.645Z" },
 ]
 
 [[package]]
@@ -2754,9 +2746,9 @@ polars = [
 ]
 ray = [
     { name = "fugue", extra = ["ray"], marker = "python_full_version < '3.14' and sys_platform != 'win32'" },
-    { name = "lightgbm-ray", marker = "python_full_version < '3.14' and sys_platform != 'win32'" },
+    { name = "lightgbm", marker = "python_full_version < '3.14' and sys_platform != 'win32'" },
+    { name = "ray", extra = ["data", "train"], marker = "python_full_version < '3.14' and sys_platform != 'win32'" },
     { name = "xgboost", marker = "python_full_version < '3.14' and sys_platform != 'win32'" },
-    { name = "xgboost-ray", marker = "python_full_version < '3.14' and sys_platform != 'win32'" },
 ]
 spark = [
     { name = "fugue", extra = ["spark"] },
@@ -2788,6 +2780,7 @@ dev = [
     { name = "pytest-codspeed" },
     { name = "pytest-cov" },
     { name = "pytest-rerunfailures" },
+    { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "setuptools" },
@@ -2807,20 +2800,20 @@ requires-dist = [
     { name = "fugue", extras = ["dask"], marker = "extra == 'dask'", specifier = ">=0.9.4" },
     { name = "fugue", extras = ["ray"], marker = "python_full_version < '3.14' and sys_platform != 'win32' and extra == 'ray'", specifier = ">=0.9.4" },
     { name = "fugue", extras = ["spark"], marker = "extra == 'spark'", specifier = ">=0.9.4" },
+    { name = "lightgbm", marker = "python_full_version < '3.14' and sys_platform != 'win32' and extra == 'ray'", specifier = ">=4.6" },
     { name = "lightgbm", marker = "extra == 'dask'" },
     { name = "lightgbm", marker = "extra == 'spark'" },
-    { name = "lightgbm-ray", marker = "python_full_version < '3.14' and sys_platform != 'win32' and extra == 'ray'" },
     { name = "narwhals" },
     { name = "optuna" },
     { name = "pandas", specifier = "<3.0" },
     { name = "polars", extras = ["numpy"], marker = "extra == 'polars'" },
     { name = "pyspark", marker = "extra == 'spark'", specifier = ">=3.3" },
+    { name = "ray", extras = ["data", "train"], marker = "python_full_version < '3.14' and sys_platform != 'win32' and extra == 'ray'", specifier = ">=2.56" },
     { name = "scikit-learn" },
     { name = "utilsforecast", specifier = ">=0.2.9" },
     { name = "xgboost", marker = "python_full_version < '3.14' and sys_platform != 'win32' and extra == 'ray'", specifier = ">=2.0.0,<2.1.0" },
     { name = "xgboost", marker = "extra == 'dask'" },
     { name = "xgboost", marker = "extra == 'spark'" },
-    { name = "xgboost-ray", marker = "python_full_version < '3.14' and sys_platform != 'win32' and extra == 'ray'", specifier = ">=0.1.19" },
 ]
 provides-extras = ["dask", "ray", "spark", "aws", "gcp", "azure", "polars"]
 
@@ -2846,6 +2839,7 @@ dev = [
     { name = "pytest-codspeed" },
     { name = "pytest-cov" },
     { name = "pytest-rerunfailures" },
+    { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "setuptools" },
@@ -4240,6 +4234,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
 name = "pytest-xdist"
 version = "3.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4373,14 +4379,14 @@ name = "ray"
 version = "2.56.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "filelock" },
-    { name = "jsonschema" },
-    { name = "msgpack" },
-    { name = "packaging" },
-    { name = "protobuf" },
-    { name = "pyyaml" },
-    { name = "requests" },
+    { name = "click", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "filelock", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "jsonschema", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "msgpack", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "packaging", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "protobuf", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "pyyaml", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "requests", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/f5/89dc8571f35355a7f889cd4709b440abf6db2c5fc8b5427b614d5084e9cb/ray-2.56.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:58b8c037a9f2b7b7866439cb6fe19d452ba3961f2b62d0a247dc3adf2ca45265", size = 66364186, upload-time = "2026-07-17T21:27:58.09Z" },
@@ -4402,11 +4408,19 @@ wheels = [
 
 [package.optional-dependencies]
 data = [
-    { name = "fsspec" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
-    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "pandas" },
-    { name = "pyarrow" },
+    { name = "fsspec", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'win32'" },
+    { name = "pandas", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "pyarrow", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+]
+train = [
+    { name = "fsspec", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "pandas", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "pyarrow", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "pydantic", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "requests", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "tensorboardx", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
 ]
 
 [[package]]
@@ -4414,9 +4428,9 @@ name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs" },
-    { name = "rpds-py" },
-    { name = "typing-extensions", marker = "python_full_version != '3.13.*'" },
+    { name = "attrs", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "rpds-py", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.13' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
@@ -4628,10 +4642,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "joblib" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "threadpoolctl" },
+    { name = "joblib", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "threadpoolctl", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
 wheels = [
@@ -4686,10 +4700,10 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "joblib" },
-    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "threadpoolctl" },
+    { name = "joblib", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "threadpoolctl", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
 wheels = [
@@ -4739,7 +4753,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -4809,7 +4823,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/56/3e/9cca699f3486ce6bc12ff46dc2031f1ec8eb9ccc9a320fdaf925f1417426/scipy-1.17.0.tar.gz", hash = "sha256:2591060c8e648d8b96439e111ac41fd8342fdeff1876be2e19dea3fe8930454e", size = 30396830, upload-time = "2026-01-10T21:34:23.009Z" }
 wheels = [
@@ -5062,6 +5076,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f4/8a/14c15ae154895cc131174f858c707790d416c444fc69f93918adfd8c4c0b/tblib-3.2.2.tar.gz", hash = "sha256:e9a652692d91bf4f743d4a15bc174c0b76afc750fe8c7b6d195cc1c1d6d2ccec", size = 35046, upload-time = "2025-11-12T12:21:16.572Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/be/5d2d47b1fb58943194fb59dcf222f7c4e35122ec0ffe8c36e18b5d728f0b/tblib-3.2.2-py3-none-any.whl", hash = "sha256:26bdccf339bcce6a88b2b5432c988b266ebbe63a4e593f6b578b1d2e723d2b76", size = 12893, upload-time = "2025-11-12T12:21:14.407Z" },
+]
+
+[[package]]
+name = "tensorboardx"
+version = "2.6.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'win32'" },
+    { name = "packaging", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "protobuf", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/a9/fc520ea91ab1f3ba51cbf3fe24f2b6364ed3b49046969e0868d46d6da372/tensorboardx-2.6.5.tar.gz", hash = "sha256:ca176db3997ee8c07d2eb77381225956a3fd1c10c91beafab1f17069adc47017", size = 4770195, upload-time = "2026-04-03T15:40:23.803Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/0f/69fbab4c30b2f3a76e6de67585ea72a8eccf381751f5c0046b966fde9658/tensorboardx-2.6.5-py3-none-any.whl", hash = "sha256:c10b891d00af306537cb8b58a039b2ba41571f0da06f433a41c4ca8d6abe1373", size = 87510, upload-time = "2026-04-03T15:40:22.111Z" },
 ]
 
 [[package]]
@@ -5406,24 +5435,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/89/92/7028e320f3099ccf74f3058ec61978bc059137ac27cec432f6261bae2990/xgboost-2.0.3-py3-none-manylinux2014_aarch64.whl", hash = "sha256:2315a57b1883221e2f78dd514559aa9797e6c272d995d22e45495a04adac93cc", size = 3935229, upload-time = "2023-12-19T21:59:22.017Z" },
     { url = "https://files.pythonhosted.org/packages/c3/eb/496aa2f5d356af4185f770bc76055307f8d1870e11016b10fd779b21769c/xgboost-2.0.3-py3-none-manylinux2014_x86_64.whl", hash = "sha256:30bd5f789fad467fd49e04e5d19e04238b931682c3951a514da5c2410b3bf59c", size = 297094586, upload-time = "2023-12-19T21:59:30.817Z" },
     { url = "https://files.pythonhosted.org/packages/24/ec/ad387100fa3cc2b9b81af0829b5ecfe75ec5bb19dd7c19d4fea06fb81802/xgboost-2.0.3-py3-none-win_amd64.whl", hash = "sha256:462f131d7bfb1bc42f67c57fa5aa3e57d2b5755b1573a6e0d2c7e8895164e0fc", size = 99750005, upload-time = "2023-12-19T22:03:10.489Z" },
-]
-
-[[package]]
-name = "xgboost-ray"
-version = "0.1.19"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
-    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "packaging" },
-    { name = "pandas" },
-    { name = "ray" },
-    { name = "wrapt" },
-    { name = "xgboost" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/3c69f1e4de9a251593211f631ddd19bb14d4678ec00e6711279cca52bd13/xgboost_ray-0.1.19.tar.gz", hash = "sha256:03e3661712daa1c2208086161881129bb6ec3e19bcd04742ace11191922236d0", size = 106107, upload-time = "2023-09-20T23:06:14.196Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/d2/49b8f3617c2b760cf30e334ba6791b3f646c0bc4eee389bb4a7d2b8ee3ae/xgboost_ray-0.1.19-py3-none-any.whl", hash = "sha256:c6956250e1686df207149962b1f18346335a65414324a2c135f88fb0b418d25b", size = 138399, upload-time = "2023-09-20T23:06:12.329Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1262,7 +1262,8 @@ version = "0.136.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
-    { name = "pydantic" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
+    { name = "pydantic", version = "2.13.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform != 'win32'" },
     { name = "starlette" },
     { name = "typing-extensions" },
     { name = "typing-inspection" },
@@ -1529,10 +1530,10 @@ dask = [
     { name = "pyarrow" },
 ]
 ray = [
-    { name = "duckdb", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
-    { name = "pandas", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
-    { name = "pyarrow", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
-    { name = "ray", extra = ["data"], marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "duckdb", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
+    { name = "pandas", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
+    { name = "pyarrow", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
+    { name = "ray", extra = ["data"], marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
 ]
 spark = [
     { name = "pyspark" },
@@ -2112,10 +2113,10 @@ name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
-    { name = "jsonschema-specifications", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
-    { name = "referencing", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
-    { name = "rpds-py", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "attrs", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
+    { name = "jsonschema-specifications", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
+    { name = "referencing", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
+    { name = "rpds-py", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
 wheels = [
@@ -2127,7 +2128,7 @@ name = "jsonschema-specifications"
 version = "2025.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "referencing", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "referencing", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
@@ -2676,7 +2677,8 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "packaging" },
     { name = "protobuf" },
-    { name = "pydantic" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
+    { name = "pydantic", version = "2.13.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform != 'win32'" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "requests" },
@@ -2702,7 +2704,8 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "packaging" },
     { name = "protobuf" },
-    { name = "pydantic" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
+    { name = "pydantic", version = "2.13.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7b/47/8a3c4f56199aadce644256684060df09f0af6ecaec460860657f2cb13b10/mlflow_tracing-3.15.0.tar.gz", hash = "sha256:e4e73243eed04d0771954b6fa17014dd21dabc67af17d4937fac2b62ec476e95", size = 1500398, upload-time = "2026-07-31T07:05:54.445Z" }
 wheels = [
@@ -2745,10 +2748,10 @@ polars = [
     { name = "polars", extra = ["numpy"] },
 ]
 ray = [
-    { name = "fugue", extra = ["ray"], marker = "python_full_version < '3.14' and sys_platform != 'win32'" },
-    { name = "lightgbm", marker = "python_full_version < '3.14' and sys_platform != 'win32'" },
-    { name = "ray", extra = ["data", "train"], marker = "python_full_version < '3.14' and sys_platform != 'win32'" },
-    { name = "xgboost", marker = "python_full_version < '3.14' and sys_platform != 'win32'" },
+    { name = "fugue", extra = ["ray"], marker = "sys_platform != 'win32'" },
+    { name = "lightgbm", marker = "sys_platform != 'win32'" },
+    { name = "ray", extra = ["data", "train"], marker = "sys_platform != 'win32'" },
+    { name = "xgboost", marker = "sys_platform != 'win32'" },
 ]
 spark = [
     { name = "fugue", extra = ["spark"] },
@@ -2798,9 +2801,9 @@ requires-dist = [
     { name = "fsspec", extras = ["gcs"], marker = "extra == 'gcp'" },
     { name = "fsspec", extras = ["s3"], marker = "extra == 'aws'" },
     { name = "fugue", extras = ["dask"], marker = "extra == 'dask'", specifier = ">=0.9.4" },
-    { name = "fugue", extras = ["ray"], marker = "python_full_version < '3.14' and sys_platform != 'win32' and extra == 'ray'", specifier = ">=0.9.4" },
+    { name = "fugue", extras = ["ray"], marker = "sys_platform != 'win32' and extra == 'ray'", specifier = ">=0.9.4" },
     { name = "fugue", extras = ["spark"], marker = "extra == 'spark'", specifier = ">=0.9.4" },
-    { name = "lightgbm", marker = "python_full_version < '3.14' and sys_platform != 'win32' and extra == 'ray'", specifier = ">=4.6" },
+    { name = "lightgbm", marker = "sys_platform != 'win32' and extra == 'ray'", specifier = ">=4.6" },
     { name = "lightgbm", marker = "extra == 'dask'" },
     { name = "lightgbm", marker = "extra == 'spark'" },
     { name = "narwhals" },
@@ -2808,10 +2811,10 @@ requires-dist = [
     { name = "pandas", specifier = "<3.0" },
     { name = "polars", extras = ["numpy"], marker = "extra == 'polars'" },
     { name = "pyspark", marker = "extra == 'spark'", specifier = ">=3.3" },
-    { name = "ray", extras = ["data", "train"], marker = "python_full_version < '3.14' and sys_platform != 'win32' and extra == 'ray'", specifier = ">=2.56" },
+    { name = "ray", extras = ["data", "train"], marker = "sys_platform != 'win32' and extra == 'ray'", specifier = ">=2.56" },
     { name = "scikit-learn" },
     { name = "utilsforecast", specifier = ">=0.2.9" },
-    { name = "xgboost", marker = "python_full_version < '3.14' and sys_platform != 'win32' and extra == 'ray'", specifier = ">=2.0.0,<2.1.0" },
+    { name = "xgboost", marker = "sys_platform != 'win32' and extra == 'ray'", specifier = ">=2.0.0,<2.1.0" },
     { name = "xgboost", marker = "extra == 'dask'" },
     { name = "xgboost", marker = "extra == 'spark'" },
 ]
@@ -3970,11 +3973,24 @@ wheels = [
 name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.11'",
+]
 dependencies = [
-    { name = "annotated-types" },
-    { name = "pydantic-core" },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
+    { name = "annotated-types", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
+    { name = "pydantic-core", version = "2.41.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
+    { name = "typing-inspection", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
 wheels = [
@@ -3982,11 +3998,43 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.13.5"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "annotated-types", marker = "python_full_version >= '3.14' and sys_platform != 'win32'" },
+    { name = "pydantic-core", version = "2.46.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform != 'win32'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.14' and sys_platform != 'win32'" },
+    { name = "typing-inspection", marker = "python_full_version >= '3.14' and sys_platform != 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/ef/fc4f868f4e2cee79f863883abffceff107875f569b848507319842d2a681/pydantic-2.13.5.tar.gz", hash = "sha256:51a9c5f7b2f8e636f04c6cada605d9b6a3bf1348fdf945a3d8869b19bba0ee08", size = 845750, upload-time = "2026-08-28T14:04:00.916Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/47/c95ffc2009878c7aac0c5e08528022dcb885933252a88b5f170058014464/pydantic-2.13.5-py3-none-any.whl", hash = "sha256:346a034f080da3755d8e9cb5e00e8b07de1d39e4f6e2c87d8ab7cafa0b269a73", size = 472589, upload-time = "2026-08-28T14:03:59.136Z" },
+]
+
+[[package]]
 name = "pydantic-core"
 version = "2.41.5"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.11'",
+]
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
 wheels = [
@@ -4097,6 +4145,108 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/f2/f11dd73284122713f5f89fc940f370d035fa8e1e078d446b3313955157fe/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:a668ce24de96165bb239160b3d854943128f4334822900534f2fe947930e5770", size = 2330317, upload-time = "2025-11-04T13:43:40.406Z" },
     { url = "https://files.pythonhosted.org/packages/88/9d/b06ca6acfe4abb296110fb1273a4d848a0bfb2ff65f3ee92127b3244e16b/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f14f8f046c14563f8eb3f45f499cc658ab8d10072961e07225e507adb700e93f", size = 2316992, upload-time = "2025-11-04T13:43:43.602Z" },
     { url = "https://files.pythonhosted.org/packages/36/c7/cfc8e811f061c841d7990b0201912c3556bfeb99cdcb7ed24adc8d6f8704/pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51", size = 2145302, upload-time = "2025-11-04T13:43:46.64Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.5"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version >= '3.14' and sys_platform != 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/f9/8a06bea35ef8daf588f707784c973a7046e0034c8d8cfb08828eeffb8b75/pydantic_core-2.46.5.tar.gz", hash = "sha256:10416c15b8839ecc4ef4d0885da76da6fd0f67333a0eb8aff6d93c4b8f2910fc", size = 472262, upload-time = "2026-08-28T10:01:31.677Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/6b/8f79692844269427abb3e4dd9e68edfcbe65ae25527d99183214de716c59/pydantic_core-2.46.5-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:657b40d6240c0a7b6a64b30f22d1e3aa631c7e846c621b0c0f6d1d75e2e15ea6", size = 2076533, upload-time = "2026-08-28T09:57:35.421Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/d0/c787604c71c2bdcda1a5656942fc822cd0f9cd879b9484bb84fc42172703/pydantic_core-2.46.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ecb42011e12ee19cafbc312887cbf3546959fe02fbad44f272d4be5baa997615", size = 1924650, upload-time = "2026-08-28T09:57:37.944Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/77/ca2f8e997d9bfdb32205297aff38f210f398822d895b1af1b59fd9df9c13/pydantic_core-2.46.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4dedce55295becb61921e386b99d4f2706045306e7fa52249a33004c837379fb", size = 1951261, upload-time = "2026-08-28T09:57:39.339Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/53/bd12e1a9255df4edee00353778e2614b5346265d51e1567ab72153e803a2/pydantic_core-2.46.5-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9f47b8a949e60f027f0aa0a6f6c7b7e9c55cbf4380d10b344e282fa4e7ab1e1b", size = 2021808, upload-time = "2026-08-28T09:57:40.69Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/41/f7f312751ebc6d6767da91964a9c7954c18e226a1720ab234e3dfb9d6c17/pydantic_core-2.46.5-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:200aa3dc9f8d54f0754f43247c0bad0999fdcfbfd2488384dd44f37279271fe6", size = 2196184, upload-time = "2026-08-28T09:57:42.275Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/93/ce93aa030ab6bac4683ba8861e7baad89dd24b02e66b8801a0e4f6a00311/pydantic_core-2.46.5-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6d30e1a4f138b8951063e9a394752a9179b51da288ffa507b1e659222f4c1793", size = 2238212, upload-time = "2026-08-28T09:57:44.122Z" },
+    { url = "https://files.pythonhosted.org/packages/34/a1/c8e6b66f499f510752c07a092dfe27621f9c255635e59d38704b5681c35a/pydantic_core-2.46.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:850a08d167dde16db8702c274f320c7be9d7da6f6dff2b58b18f9e815bd94f5b", size = 2064073, upload-time = "2026-08-28T09:57:45.613Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/fa/605e2b127ee30dbf4b1da9da4843587cf2b2d16486c241cc7a5be2d2c1bd/pydantic_core-2.46.5-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:c3471e5c4a949c26ec00a77f01df59096aa9495877de76fd60a980f8ee6be461", size = 2093102, upload-time = "2026-08-28T09:57:46.953Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/f7/1ab28093c09032ddce7c92c7a55d503b6ecd70f42c32492946c1cb5477b1/pydantic_core-2.46.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3a3e26b6a8274211bddee2d0e4d0d42778f17a34510f49d2ec44b58abfc41736", size = 2133452, upload-time = "2026-08-28T09:57:48.362Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c8/47c79b756f12f85e8b0fbdb2b495f6b6eb32e6c98a4beae7a570a0b7c63c/pydantic_core-2.46.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:fc5d783bd4a2387e97b8a2d5ec781cfb92b3d893bf82370548e99db5915935d3", size = 2146477, upload-time = "2026-08-28T09:57:49.74Z" },
+    { url = "https://files.pythonhosted.org/packages/13/5c/79fc00cb8f651d6061991de8d7cedf1c78c73cbd4862c42ef418f03b8bfa/pydantic_core-2.46.5-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:356c8368cbc321050b169595683a2e1d63413b1e0e2868b330af9fc14c616d3f", size = 2300832, upload-time = "2026-08-28T09:57:51.639Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/72/dd1a29853cf6d22a1ebd9e3baf0239cbc57d2d16caff36a89e38eb9b1db3/pydantic_core-2.46.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:eb7d8d0e5886a89a55d2eef490e272fa965a9d57c6b29a5b5088a7997ec2cad1", size = 2320505, upload-time = "2026-08-28T09:57:53.236Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/b6/81d2d19ea0be2c03664381b59f65fa72fc7969decedae00bc2c4ad835708/pydantic_core-2.46.5-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a1dee1b804ff4d11c663636cf15d2ea47e9f79cd56c033fb1cbf08924842a48f", size = 2074737, upload-time = "2026-08-28T09:57:57.711Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/18/b70da8300e292df4099684ea11b1958043580d2f50d2dc8bf7e542bdd84a/pydantic_core-2.46.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d625a186a65201c23a9e3b8ed9c47e90a026e03256608cc91851c6709096844f", size = 1921751, upload-time = "2026-08-28T09:57:59.265Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/1a/0d590341b6ffa4b4aca83508e6b8db4761aaeacfc15a25ca3815876d4797/pydantic_core-2.46.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f8507560a9284e1370bb048ed4282012fbef4e8d109875b95e884d228552061", size = 1948231, upload-time = "2026-08-28T09:58:00.678Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/1d/02eb35761c51f2f7b1b042d6ab4cda6600f0c8c88a2243b3f734376201e5/pydantic_core-2.46.5-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f93c5fe914d75fbec9a49209b00da5f08e9e467d69da2b1510c81940cfd10be", size = 2020708, upload-time = "2026-08-28T09:58:02.267Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/ea/f86073830e35d508cc8ddf9c3d9e6e6840fcb88d34bf726b0b4710186f27/pydantic_core-2.46.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c767f552b21b10f774aeac128e828eafb796adfa1b666a18bf6321453c3a", size = 2194914, upload-time = "2026-08-28T09:58:03.934Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/d7/fc36240d7791ce90939e51608568c33bfdae26202016f9770c229a487d86/pydantic_core-2.46.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:701b2e04b560eeb4bddf7a25ab8ca476176e34fdbd9a0e18196f0d12d4685f0b", size = 2235622, upload-time = "2026-08-28T09:58:05.516Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/bc/3fa2d76b83162820a17da7f645b28d1cba99fc8e1e5fc6517067ec450fa1/pydantic_core-2.46.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49776eab08766a08dfff7012f8b422dcd7e25e43b316eedf0477c24fcfa84b7c", size = 2062091, upload-time = "2026-08-28T09:58:07.135Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/9a/095d557bb492c90cd8a70a6dd048bf793d433d03d86c81c11e912e4cd049/pydantic_core-2.46.5-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:a2468d93d181667a7abd66e1b64bb9f76f361b0fef8faddf687456453576f5ee", size = 2089904, upload-time = "2026-08-28T09:58:08.814Z" },
+    { url = "https://files.pythonhosted.org/packages/24/98/7b76b1ad10a19a617a52aaa1d80e159115af939b095e86f8e756fd52e0df/pydantic_core-2.46.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:53feb344243bb9510a9dec7bf3cf1b64d88a98af5dc7872a5160465f8b198c8e", size = 2132244, upload-time = "2026-08-28T09:58:10.435Z" },
+    { url = "https://files.pythonhosted.org/packages/20/32/7d6ca365fadba186a0c8f85de1a701663bce81efd309d9479be58687622f/pydantic_core-2.46.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:cd5214352ae68f3b5e9af7768bdc5253695ee069675db3480518420b3be881f2", size = 2143901, upload-time = "2026-08-28T09:58:12.033Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/09/eb9a6aa57f22fd1541a9c0aa2a1f3aeef3ec65347d33e10a6da2f43e0ee9/pydantic_core-2.46.5-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:9432f3598db432cb51c5b37fdbf29a60fcccc79e30d37a05022776a6bc4ab689", size = 2299425, upload-time = "2026-08-28T09:58:13.614Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f9/548a5bb9d4ba8cd26e26daf48052236f6b38bb61e7b7241fbc3c995719eb/pydantic_core-2.46.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:8feeac04b5794e513e710af2f9c87d49f31a6dc47967bb264a1fed61a8989bec", size = 2318566, upload-time = "2026-08-28T09:58:15.199Z" },
+    { url = "https://files.pythonhosted.org/packages/82/3f/76358795aa7a8c6d4f36e2cb828ad1c90ee118e1393a9281664f5aade9d4/pydantic_core-2.46.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:b9fe6fb92520e3fd61f2e49000b6911b188824f089b75973ea06d6267f0b476d", size = 2076516, upload-time = "2026-08-28T09:58:21.576Z" },
+    { url = "https://files.pythonhosted.org/packages/db/50/26b091836076ce4cb2fac264186936acc069e0595772cfd02a563bc4761a/pydantic_core-2.46.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a39ac25a9a2fa4072efdb429833c4a4c8009a51ff9eea3eeae131713cd27991e", size = 1922874, upload-time = "2026-08-28T09:58:23.766Z" },
+    { url = "https://files.pythonhosted.org/packages/09/f0/2a8ce3849e299d44e2d2c196b6082643a3235565a735cb51db7a6261f614/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4fdc8b93a41521988916eeaa271173fcca7fa0803d62f87675aac8dcec1c8e29", size = 1951772, upload-time = "2026-08-28T09:58:25.435Z" },
+    { url = "https://files.pythonhosted.org/packages/87/46/ac0dc8bdd9e6048183a14eb127764e7ad9240021c17513074a4711b0e31e/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b98134087d9de723658d17a42c7d0da8d6e2ef08015dee7dc93889047315f5e4", size = 2031832, upload-time = "2026-08-28T09:58:27.102Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c2/339de5bef7be36301a2231eaa52e62163742c2281f11b5f4892bc79785cd/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e652ab17569c94bff5475520f907b7148b8c24036a8ebbe5cf7cf7493d28579a", size = 2208645, upload-time = "2026-08-28T09:58:28.948Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/a0/9ff22b797724262da14427abaed4dd1d864a139693fc5e7809114376a716/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d925f3d9afd05a8c0fb3a1031463a8d59ebe5e2afad297e29c78be19e13b4e62", size = 2265935, upload-time = "2026-08-28T09:58:30.625Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a4/eb9409ec0736e50aa70a412f16c204ed149516846912f7e6724d4c73ee53/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0fc5be0abd4a407e200d844b404e33639a554e7bd0d448e7b9ae181be4789ac2", size = 2066284, upload-time = "2026-08-28T09:58:32.289Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/02/7f6156ffc926857f1c37c07d9a388682865a81830ab6a1b637082c25e399/pydantic_core-2.46.5-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:816ff0a6550ffc06c098ccd2e0698600f9aa7da192a79eaa6f9af504a35db869", size = 2105889, upload-time = "2026-08-28T09:58:33.986Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b1/e781d357ebe09fc929f995700f1b3503e8897f1cece183ecb1300d4d67e9/pydantic_core-2.46.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c7ea57fc63aa7da93a1bd2d644e6577befae10c52c4e36377635eea1056a74f5", size = 2158006, upload-time = "2026-08-28T09:58:35.647Z" },
+    { url = "https://files.pythonhosted.org/packages/70/0a/644597d84ab400e50609c192120b85c9681c22d3a20461b9060a79be0a7a/pydantic_core-2.46.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:efd62a42486f1bda5d24cb4f63d15a3c7768375fe83d36f9417b4ad7a2fb20b3", size = 2158408, upload-time = "2026-08-28T09:58:37.38Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/ee/ca3b7b3a4b3769ffe9ce9432a7c9be755de9593a46d3b0d54d0409323e44/pydantic_core-2.46.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:2bc9419666990c06d7397831f2126a1ecc3594aaa3ff7de5bf2d066802f4e07b", size = 2309609, upload-time = "2026-08-28T09:58:39.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/52/39fa1f451486019524ca685020390e7ca351832fd874530ba30c8628e6dc/pydantic_core-2.46.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:18a09e1e1011b462f2e32774f25859ef1223d5c2b0546a633cf56654710721e0", size = 2342618, upload-time = "2026-08-28T09:58:40.89Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/37/5abe39a8372a61d3dc3c1338fc504281c01b32fdb3169cd7187153b56d3e/pydantic_core-2.46.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:b7ca9034437b6022f941f4857459562ee00a560b97e7cce8a0ec5a74fc6766e0", size = 2075885, upload-time = "2026-08-28T09:58:47.856Z" },
+    { url = "https://files.pythonhosted.org/packages/21/43/6323b1f8b217780454c61304bcd2b38ae4762f50754414124603ccc90bb2/pydantic_core-2.46.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f332f0e72a5a0400141f830744e141bf9f97917878dbe968669e8a7fefea78ff", size = 1922768, upload-time = "2026-08-28T09:58:49.58Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/a3/c05ca796e1197618a774b01e596aeedfefc2f7d8c01ae3054e910b120e8a/pydantic_core-2.46.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:193375f3548919d3f0b60936ca113ada3e38f264f91b9b8e0508efaad57be931", size = 1951241, upload-time = "2026-08-28T09:58:51.511Z" },
+    { url = "https://files.pythonhosted.org/packages/68/32/33bc39ac705c52cffc908e8389f9754fdb208aea5c69cceddf4eb3ce99af/pydantic_core-2.46.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:79bdfa52f843137045b2d081cc05c120ba6665d29b7559c2c47690906f39279f", size = 2031975, upload-time = "2026-08-28T09:58:53.166Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/70/2333e885c0f6a67bc105c5916965dac9b57f2718ee20d81d1a06a4ebdc13/pydantic_core-2.46.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:24922243639cbdac66c75fcb6fd6495a9cb52b213d62f9a0d16f0310b1ff8038", size = 2208542, upload-time = "2026-08-28T09:58:55.017Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ea/296debfb4264207bbda5936133892e027c0a58875ad53ebd512fba8ec3a2/pydantic_core-2.46.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c76fe65e607be28c7fd4d56fc3c42b1583aa058ce3408b7ad0fd540171d31f9f", size = 2264692, upload-time = "2026-08-28T09:58:56.767Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/9e4de77a6271e07a76d2d58b11c091a979c191ed2939bf80067568b369d2/pydantic_core-2.46.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f7b393a8b3da82f5c1fc0751e6d01ac6c55b93c18226a60bdfba4a724efafd1", size = 2066633, upload-time = "2026-08-28T09:58:58.531Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/db/f9e9d0c97445987b2084823d5c240de88087338f04fc2cfaa2df186b8049/pydantic_core-2.46.5-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:7ac031912d54f3d83ef3b3eb98dfabc1608802e2202263d25957eeed40b94761", size = 2105235, upload-time = "2026-08-28T09:59:00.421Z" },
+    { url = "https://files.pythonhosted.org/packages/07/c5/79169b047b3b2c3e99e04bc76372af9637e0bf6db638274fa927df96369e/pydantic_core-2.46.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:837b396ca3d7b74091ca623f6cbd8351bd42d670a79c2683e79fb089f06a2de5", size = 2157367, upload-time = "2026-08-28T09:59:02.442Z" },
+    { url = "https://files.pythonhosted.org/packages/26/b5/ba6057afb7c291bd449f51b867f95aef2072941c4ce4e5c31d6ffd132d3b/pydantic_core-2.46.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:5ee239d575f80b08eca11f6e20f90c4c695de7825c67eefe6091fbf20dda648e", size = 2158420, upload-time = "2026-08-28T09:59:04.2Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/28/2057abecaafdc22912afa819603a51f0a62d40643b7c4871c51721fea9be/pydantic_core-2.46.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:e80675d75ae2cd14372cb65cad5400d9347a3d3f6c13000183f22dfd027283ed", size = 2309588, upload-time = "2026-08-28T09:59:06.048Z" },
+    { url = "https://files.pythonhosted.org/packages/71/9d/881156dc404e27479c4246128d73538464cab4a239bec61995e227644c30/pydantic_core-2.46.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:9c4b71f10dd532fb7a5cbc8f58707779e64f03a258c2bf8bfbaecfcd9970b519", size = 2341866, upload-time = "2026-08-28T09:59:08.539Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/8a/14596f2a8367da50cf7cbac48169ee5d9c8e11d486a3b527082384630c72/pydantic_core-2.46.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c1c43ad4339643d70ebb8124e1305a7dab423001eff58bb41a0f731adbc98355", size = 2074081, upload-time = "2026-08-28T09:59:16.141Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/d5/d8a4eb6d6c7f66b91dd37c576d76e9e60fba900caf5372c17bcf949febc2/pydantic_core-2.46.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1a353f84de772f423b5ffb11d7ae352fbbef0f446f3c0b0af0f8236d7233606e", size = 1920497, upload-time = "2026-08-28T09:59:18.065Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/26/092079428f86e927e030b2c0ced87df69dbb1c875cdeaa67bf42ea2be746/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5086029a57366b8cf81b130a43908738095c270c21a8d7f0e8bdfdb89718e2f3", size = 1952130, upload-time = "2026-08-28T09:59:20.476Z" },
+    { url = "https://files.pythonhosted.org/packages/08/c3/8ec0e290a9ebaebd64047bf5fda94be835c6b1551b02437e4b76778fbcd7/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:46c25dda9d092a06c08db76ffe0a197107904d0dfac653f7d5306bbcd6d6119c", size = 2026371, upload-time = "2026-08-28T09:59:22.227Z" },
+    { url = "https://files.pythonhosted.org/packages/01/72/4fd20ad520fb8da0157f95b27a7eb05a72790ef08138e7701ac972c342ea/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:37ea7b83c935e5b0d68c9449b82651accf78a10828b2c02b2f2d9e9496446c21", size = 2202822, upload-time = "2026-08-28T09:59:24.277Z" },
+    { url = "https://files.pythonhosted.org/packages/31/b0/d16e0771206b29314f0d52198b720be21e8a99ab2bf11e3bc0d7c9cebdff/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e64e88d5585bea9ce95861079de72006c7fa6d3df4e3a3b65ba31eb979c15c9f", size = 2262756, upload-time = "2026-08-28T09:59:26.608Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/9b/59634b7ac631c63b2a37760eb6943af3e29573d6b59a4abc5e7f019d4cee/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54d510bac3ee52247af28ed4bb18a1e799f040ac60fd2bf5ccd4c92f1fbe786f", size = 2068352, upload-time = "2026-08-28T09:59:29.044Z" },
+    { url = "https://files.pythonhosted.org/packages/08/7c/570abb1ad2155348dc754ea91be22e5aaa18eb6d69a6068f7c6f2679a6ed/pydantic_core-2.46.5-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:a2a5e1d0ff29adddc9f6d6821a66302e4493f8ca898b715b6b1182c2c201ea0a", size = 2104777, upload-time = "2026-08-28T09:59:30.95Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/25/5bf74adc65a1ac5b7be3f6cb0bcb5433615c1598a801c19d830d84c98ded/pydantic_core-2.46.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:03b9666e41e35d8909852ba191a0607520f81b74eaf12ccf8737005dbb313821", size = 2156312, upload-time = "2026-08-28T09:59:32.604Z" },
+    { url = "https://files.pythonhosted.org/packages/90/6a/2ef38830675e050121040618135564ed56b860b45433b02d9b4ebece46f3/pydantic_core-2.46.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:a91c17edf6eea2402cb5457b4c89e99bc5ed1004aa34c4adf1d4258c1a5c22c2", size = 2150067, upload-time = "2026-08-28T09:59:34.453Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ef/a7dbb03a14a64c2a4621f989c615ed9a892535a6cad938fc27079f919d80/pydantic_core-2.46.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b49924c73a235e969511bf2aabdff3beebf9820931f646c80274d5d780010c47", size = 2304516, upload-time = "2026-08-28T09:59:36.194Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f8/6bb4c4b80e8a6fde1904c64a51c62a1d04fcdfa3ea521a66b2ddefa1d885/pydantic_core-2.46.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:2cbd9a5eff05e51c447c34dfa4632145b26b09120cf04bd0c871e44c1a5e1c9a", size = 2335223, upload-time = "2026-08-28T09:59:37.931Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/66/9336ae58f9eb68c41d121894e52c4c89eccb07eb8f602a04ee9c3f37736a/pydantic_core-2.46.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8816f3d218beb4b787de5c9759c259b8fa61f9dec42dc7811f320a33771778b7", size = 2065829, upload-time = "2026-08-28T09:59:45.364Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/02/bc19b47a96c2d3109760711acf22369e56bd7e405ca52f7ade164d2ead57/pydantic_core-2.46.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:bce57638e08ac148e5778cce7feb968307a727d66f8e2274a543d0cf0c9ad6a3", size = 1905716, upload-time = "2026-08-28T09:59:47.18Z" },
+    { url = "https://files.pythonhosted.org/packages/52/a4/70b47c0509923dd98ccfed04fb3e32ea3849c82a0ff2205bb41009b43c00/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:976e1128455aa595ea04c79ccfedff1aaeab96ee013fcc916bed120c4f0ad94f", size = 1934216, upload-time = "2026-08-28T09:59:49.241Z" },
+    { url = "https://files.pythonhosted.org/packages/52/ab/aa03b65f7bb198585edf806b906c3223ecf1795543e39e23aec4cce27ad2/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e7b891faeedeafba41b2983e5001a81b6a915b69544c7e7570d1989ce1c36ac7", size = 2010635, upload-time = "2026-08-28T09:59:51.692Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/8b/0da06343f30b84ec549aafd309c6456223d5dc8bd36af504c573faad561d/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5f194189415698233dd1114a093a9b56e61e2c57e11b469be3b0506f46f0771c", size = 2209369, upload-time = "2026-08-28T09:59:53.582Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5b/844c4defaa34a3df66eb9257087d121d70c201298b96abdf9f492fc2f1bf/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:82a36973cf8a2ef5406f4fe2edbf8ed0c99629535d959e0b100c76a32535a111", size = 2253238, upload-time = "2026-08-28T09:59:55.484Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/64/a4e536cb16d7f61a7fd3120b46c577fc7fa7325992f69c4f52bc786d77d8/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cdbb78909f52b981d3b2d56b97328d71eb0b974c36bd77c920123a7ebb192829", size = 2065740, upload-time = "2026-08-28T09:59:58.038Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/75/aaa38c6bc2d085f6605b34eabdc6a8a4e0b2e61fc9c8e6e52b28e97b3125/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:52e24eacdb536cade636aa90fb851835222becff8484b7001fdc78cb0290f2aa", size = 2087425, upload-time = "2026-08-28T09:59:59.898Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ae/fcab4cfc39aba3689e1d20c8b5250ad280957022c09af2ed9cd585602a5e/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:37ae34309d7bd8c0d61ab839668058f2a7962ea1fc51d105d2db228fe0618034", size = 2139306, upload-time = "2026-08-28T10:00:03.057Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/f4/f1d03a4bc9d9acbc62f4d742b8a319af52f71885079868b2ff8e48a651ee/pydantic_core-2.46.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:0cdbada856a1c69a7624a64d3d9aefe79300bd6ef827b43a4f265010b9b55184", size = 2144589, upload-time = "2026-08-28T10:00:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/83/f3/7a53bb1356de514a4cd295f25b6ac39237895620c0462d2592b76c16e114/pydantic_core-2.46.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:545f26c504b27c3758439a5e6d9349931f0a04f855668d5fe323c89e82300a38", size = 2288882, upload-time = "2026-08-28T10:00:07.931Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/94/5a81583660c175c59d49ffb09f4b3a44debeaf86a19fca664ae1cdd9ee32/pydantic_core-2.46.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:ff218293c9c806138dca139765e3b067621be52bcd93cdc14c7711be7ddc90a9", size = 2335210, upload-time = "2026-08-28T10:00:10.177Z" },
+    { url = "https://files.pythonhosted.org/packages/af/1e/ecca01fce348f7e8afa9572441ff6f7d1cc70d21e4859f33944d10877e1e/pydantic_core-2.46.5-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:c14ad3bdc85ee7f318742c457ca3968a92126d144b15721c759033bfb06296c2", size = 2075342, upload-time = "2026-08-28T10:00:51.353Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/4c/af80c7a8032dfc897040ad5cb772bebde529a381186499e6e29987f23f8c/pydantic_core-2.46.5-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0bddb4020d8f04175865ccd17eff3040874fc11fb593f424edb452653b4b947c", size = 1907219, upload-time = "2026-08-28T10:00:53.438Z" },
+    { url = "https://files.pythonhosted.org/packages/be/3e/54d89e2b092e778716bf6153634ef479e955f48c261090be23aa1e0fb0b5/pydantic_core-2.46.5-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2471fd51c61c610e1dcf7de44d7299283661654d11264ab4802b303368d69c47", size = 1953393, upload-time = "2026-08-28T10:00:55.58Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/89/828ee90cda28ce17bdefaa3a6eaf74fe430e113295a10e6126beca559d6c/pydantic_core-2.46.5-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b10ec717381bdbfafef34607824db4c91de69ff085e4fca3b2af91b4fa17e68a", size = 2099024, upload-time = "2026-08-28T10:00:57.794Z" },
+    { url = "https://files.pythonhosted.org/packages/df/dd/053c2e4303f791f3b8f8a14ab0b22008e8eb21d868c0c90b4f9be705b76a/pydantic_core-2.46.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:013d6f3483d81e02e7c328831808f336c8596ee33b4bd4026b9ffb1e960b8942", size = 2062540, upload-time = "2026-08-28T10:01:00.318Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/dd/a18df751a5e37dd51bfad7f68e766999125bebe68c9e1d10a493ad01bd63/pydantic_core-2.46.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:e9c134bb666dd54b778b9fc0d2b50cbb7f979b9e3716f26a88c9ab3b6fc1dd0f", size = 1902040, upload-time = "2026-08-28T10:01:02.529Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/13/01d40f9d07ce8a779fd6e0bd8ad4fba91309500dd67b869e2e219d261a6d/pydantic_core-2.46.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:347ec774390c87326a2e4929d58d3f7e8763a104d5d35f4cd595a4c952366433", size = 1967479, upload-time = "2026-08-28T10:01:05.004Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/04/c81d4841331c2178b6fb09ae225425e110ed72d990c9fe556c4ec03d1013/pydantic_core-2.46.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e24d8f05fa2d28513d94e877e9c75ad66175376209b3977f916e240e623193c", size = 2111034, upload-time = "2026-08-28T10:01:07.345Z" },
+    { url = "https://files.pythonhosted.org/packages/20/21/22102e9950b3049526d20e811b95396508377d87651edd2b80d2b3d28659/pydantic_core-2.46.5-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:ab4b66edffb32d9e951efb3814bd104b8367a7501b81b955cacb5726d897389f", size = 2071333, upload-time = "2026-08-28T10:01:09.636Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/18/87aefa427d191e6d3ab1447f1efc1cdcac86af1069239b133e8a0fd7f7c9/pydantic_core-2.46.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:337639ba62a11acde6ef3aeb08c8ea755f8ef1fe5e513356c0f36a2b0d7568b0", size = 1912713, upload-time = "2026-08-28T10:01:12.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/93/fd89e9ad49b1805ca94d24ce1088b7d305f05c35ffafcedb9819d03588a0/pydantic_core-2.46.5-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:413a717a410d0c817ef5b786a059415550b3794e1d0c2abffd9efb93a3d9f7b4", size = 2090926, upload-time = "2026-08-28T10:01:15.19Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/45/8e59dab6acf8d35f02f0a958980074f31038968bdb2c983fcae9d1efee03/pydantic_core-2.46.5-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1e449def1945a462c464331254e5a44fca7c3b4f9aedf59ec2f50f8066dd8e25", size = 2131303, upload-time = "2026-08-28T10:01:17.937Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/a5/e1d4dc5180dd887a9522efc1f8716b8692b7606b1d3273d7862eaf66be44/pydantic_core-2.46.5-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:a445486499897b88a7d6c310c88ed64dd37b1b59bfd7ae9107490bbb362f47d6", size = 2145128, upload-time = "2026-08-28T10:01:20.694Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/d7/ad493864a7fb21c0c4df98f965e2db430cb25a9d7369b5778d5016c09fd9/pydantic_core-2.46.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:2d330aaba8621b1edcec8ae2c4050f63b84ccf6d98723a8f212e9684713abf0e", size = 2294560, upload-time = "2026-08-28T10:01:23.495Z" },
+    { url = "https://files.pythonhosted.org/packages/02/8e/b41c84c913f29973a268e6c2b5bbf13c95adb9956c126d10da11ba3b2bef/pydantic_core-2.46.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:b6acfb46a814762367fb7ba0828b0a17d441b92ce249a0e007474c9072662dda", size = 2317531, upload-time = "2026-08-28T10:01:26.334Z" },
 ]
 
 [[package]]
@@ -4379,14 +4529,14 @@ name = "ray"
 version = "2.56.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
-    { name = "filelock", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
-    { name = "jsonschema", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
-    { name = "msgpack", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
-    { name = "packaging", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
-    { name = "protobuf", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
-    { name = "pyyaml", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
-    { name = "requests", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "click", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
+    { name = "filelock", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
+    { name = "jsonschema", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
+    { name = "msgpack", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
+    { name = "packaging", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
+    { name = "protobuf", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
+    { name = "pyyaml", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
+    { name = "requests", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/f5/89dc8571f35355a7f889cd4709b440abf6db2c5fc8b5427b614d5084e9cb/ray-2.56.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:58b8c037a9f2b7b7866439cb6fe19d452ba3961f2b62d0a247dc3adf2ca45265", size = 66364186, upload-time = "2026-07-17T21:27:58.09Z" },
@@ -4408,19 +4558,20 @@ wheels = [
 
 [package.optional-dependencies]
 data = [
-    { name = "fsspec", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "fsspec", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'win32'" },
-    { name = "pandas", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
-    { name = "pyarrow", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and sys_platform != 'win32'" },
+    { name = "pandas", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
+    { name = "pyarrow", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
 ]
 train = [
-    { name = "fsspec", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
-    { name = "pandas", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
-    { name = "pyarrow", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
-    { name = "pydantic", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
-    { name = "requests", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
-    { name = "tensorboardx", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "fsspec", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
+    { name = "pandas", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
+    { name = "pyarrow", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "pydantic", version = "2.13.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform != 'win32'" },
+    { name = "requests", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
+    { name = "tensorboardx", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
 ]
 
 [[package]]
@@ -4428,8 +4579,8 @@ name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
-    { name = "rpds-py", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "attrs", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
+    { name = "rpds-py", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
     { name = "typing-extensions", marker = "(python_full_version < '3.13' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
@@ -5084,9 +5235,9 @@ version = "2.6.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'win32'" },
-    { name = "packaging", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
-    { name = "protobuf", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and sys_platform != 'win32'" },
+    { name = "packaging", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
+    { name = "protobuf", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/a9/fc520ea91ab1f3ba51cbf3fe24f2b6364ed3b49046969e0868d46d6da372/tensorboardx-2.6.5.tar.gz", hash = "sha256:ca176db3997ee8c07d2eb77381225956a3fd1c10c91beafab1f17069adc47017", size = 4770195, upload-time = "2026-04-03T15:40:23.803Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -2739,7 +2739,8 @@ dask = [
     { name = "dask", extra = ["complete"] },
     { name = "fugue", extra = ["dask"] },
     { name = "lightgbm" },
-    { name = "xgboost" },
+    { name = "xgboost", version = "3.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "xgboost", version = "3.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 gcp = [
     { name = "fsspec", extra = ["gcs"] },
@@ -2751,13 +2752,15 @@ ray = [
     { name = "fugue", extra = ["ray"], marker = "sys_platform != 'win32'" },
     { name = "lightgbm", marker = "sys_platform != 'win32'" },
     { name = "ray", extra = ["data", "train"], marker = "sys_platform != 'win32'" },
-    { name = "xgboost", marker = "sys_platform != 'win32'" },
+    { name = "xgboost", version = "3.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' and sys_platform != 'win32'" },
+    { name = "xgboost", version = "3.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and sys_platform != 'win32'" },
 ]
 spark = [
     { name = "fugue", extra = ["spark"] },
     { name = "lightgbm" },
     { name = "pyspark" },
-    { name = "xgboost" },
+    { name = "xgboost", version = "3.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "xgboost", version = "3.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 
 [package.dev-dependencies]
@@ -2788,7 +2791,8 @@ dev = [
     { name = "ruff" },
     { name = "setuptools" },
     { name = "statsmodels" },
-    { name = "xgboost" },
+    { name = "xgboost", version = "3.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "xgboost", version = "3.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 
 [package.metadata]
@@ -2814,7 +2818,7 @@ requires-dist = [
     { name = "ray", extras = ["data", "train"], marker = "sys_platform != 'win32' and extra == 'ray'", specifier = ">=2.56" },
     { name = "scikit-learn" },
     { name = "utilsforecast", specifier = ">=0.2.9" },
-    { name = "xgboost", marker = "sys_platform != 'win32' and extra == 'ray'", specifier = ">=2.0.0,<2.1.0" },
+    { name = "xgboost", marker = "sys_platform != 'win32' and extra == 'ray'" },
     { name = "xgboost", marker = "extra == 'dask'" },
     { name = "xgboost", marker = "extra == 'spark'" },
 ]
@@ -3316,6 +3320,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/33/9b/9dd6e2db8d49eb24f86acaaa5258e5f4c8ed38209a4ee9de2d1a0ca25045/numpy-2.4.1-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2023ef86243690c2791fd6353e5b4848eedaa88ca8a2d129f462049f6d484696", size = 14538937, upload-time = "2026-01-10T06:44:51.498Z" },
     { url = "https://files.pythonhosted.org/packages/53/87/d5bd995b0f798a37105b876350d346eea5838bd8f77ea3d7a48392f3812b/numpy-2.4.1-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8361ea4220d763e54cff2fbe7d8c93526b744f7cd9ddab47afeff7e14e8503be", size = 16479830, upload-time = "2026-01-10T06:44:53.931Z" },
     { url = "https://files.pythonhosted.org/packages/5b/c7/b801bf98514b6ae6475e941ac05c58e6411dd863ea92916bfd6d510b08c1/numpy-2.4.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:4f1b68ff47680c2925f8063402a693ede215f0257f02596b1318ecdfb1d79e33", size = 12492579, upload-time = "2026-01-10T06:44:57.094Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu12"
+version = "2.31.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/85/b073e54c993cd9f79faa955d7c9bd7356da408935483aebc3cbb53a922ec/nvidia_nccl_cu12-2.31.2-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:f208de397e431631eab0eca946444404a495d43a007535baa333d7de9e510ca2", size = 342026203, upload-time = "2026-08-11T23:23:40.509Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/36/104de52d6368f5b7f886e8fd252e0a438fe73a215e59b1b47f93a80ae2ea/nvidia_nccl_cu12-2.31.2-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:f9b1dc3c2a7e20176054144ebb3b32fea83b40402ee5d7ac7045cd11ecc956c0", size = 342105414, upload-time = "2026-08-11T23:24:24.167Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu13"
+version = "2.31.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/a0/530efd7db8857c0436868bb7df9764f09fde2bd4d1f0bae546eec9fc40d0/nvidia_nccl_cu13-2.31.2-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:b5563f8e2534f363d93ace022670ba016d3717e190ac4eba564d05fbbe8495b1", size = 252479893, upload-time = "2026-08-11T23:22:01.53Z" },
+    { url = "https://files.pythonhosted.org/packages/14/fb/94933e00bb3dcfdf66ea3456739c6a51d322353f7cc64fa1f5f660e695ac/nvidia_nccl_cu13-2.31.2-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:0bcaf0308854cb55fcc35af72e2c83143f3b71e65a4e865e2c586b1cdcdb5ae0", size = 252442223, upload-time = "2026-08-11T23:22:40.341Z" },
 ]
 
 [[package]]
@@ -5571,21 +5593,58 @@ wheels = [
 
 [[package]]
 name = "xgboost"
-version = "2.0.3"
+version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.11'",
+]
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "nvidia-nccl-cu12", marker = "python_full_version < '3.12' and sys_platform == 'linux'" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/53/4a/316018e4d5d47f2a671d89e2ee5a8b6686689e7576258929b222b07aa097/xgboost-2.0.3.tar.gz", hash = "sha256:505955b5d770f8217a049beecce79e04a93787371c06dfb4b2414fec9d496bf3", size = 1048322, upload-time = "2023-12-19T22:01:10.965Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/bb/1eb0242409d22db725d7a88088e6cfd6556829fb0736f9ff69aa9f1e9455/xgboost-3.2.0.tar.gz", hash = "sha256:99b0e9a2a64896cdaf509c5e46372d336c692406646d20f2af505003c0c5d70d", size = 1263936, upload-time = "2026-02-10T11:03:05.542Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/6d/8c1d2570a52db6263d855c3ee3daf8f4bdf4a365cd6610772d6fce5fd904/xgboost-2.0.3-py3-none-macosx_10_15_x86_64.macosx_11_0_x86_64.macosx_12_0_x86_64.whl", hash = "sha256:b21b2bb188b162c615fce468db93e3f995f3690e6184aadc7743b58466dc7f13", size = 2189605, upload-time = "2023-12-19T21:59:17.35Z" },
-    { url = "https://files.pythonhosted.org/packages/03/e6/4aef6799badc2693548559bad5b56d56cfe89eada337c815fdfe92175250/xgboost-2.0.3-py3-none-macosx_12_0_arm64.whl", hash = "sha256:722d5b9351dfdf61973490dfd28abd42844db1cc469d07ed9b0cde9d1ffcdb32", size = 1949100, upload-time = "2023-12-19T21:59:20.193Z" },
-    { url = "https://files.pythonhosted.org/packages/89/92/7028e320f3099ccf74f3058ec61978bc059137ac27cec432f6261bae2990/xgboost-2.0.3-py3-none-manylinux2014_aarch64.whl", hash = "sha256:2315a57b1883221e2f78dd514559aa9797e6c272d995d22e45495a04adac93cc", size = 3935229, upload-time = "2023-12-19T21:59:22.017Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/eb/496aa2f5d356af4185f770bc76055307f8d1870e11016b10fd779b21769c/xgboost-2.0.3-py3-none-manylinux2014_x86_64.whl", hash = "sha256:30bd5f789fad467fd49e04e5d19e04238b931682c3951a514da5c2410b3bf59c", size = 297094586, upload-time = "2023-12-19T21:59:30.817Z" },
-    { url = "https://files.pythonhosted.org/packages/24/ec/ad387100fa3cc2b9b81af0829b5ecfe75ec5bb19dd7c19d4fea06fb81802/xgboost-2.0.3-py3-none-win_amd64.whl", hash = "sha256:462f131d7bfb1bc42f67c57fa5aa3e57d2b5755b1573a6e0d2c7e8895164e0fc", size = 99750005, upload-time = "2023-12-19T22:03:10.489Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/49/6e4cdd877c24adf56cb3586bc96d93d4dcd780b5ea1efb32e1ee0de08bae/xgboost-3.2.0-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:2f661966d3e322536d9c448090a870fcba1e32ee5760c10b7c46bac7a342079a", size = 2507014, upload-time = "2026-02-10T10:50:57.44Z" },
+    { url = "https://files.pythonhosted.org/packages/93/f1/c09ef1add609453aa3ba5bafcd0d1c1a805c1263c0b60138ec968f8ec296/xgboost-3.2.0-py3-none-macosx_12_0_arm64.whl", hash = "sha256:eabbd40d474b8dbf6cb3536325f9150b9e6f0db32d18de9914fb3227d0bef5b7", size = 2328527, upload-time = "2026-02-10T10:51:17.502Z" },
+    { url = "https://files.pythonhosted.org/packages/96/9f/d9914a7b8df842832850b1a18e5f47aaa071c217cdd1da2ae9deb291018b/xgboost-3.2.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:852eabc6d3b3702a59bf78dbfdcd1cb9c4d3a3b6e5ed1f8781d8b9512354fdd2", size = 131100954, upload-time = "2026-02-10T11:02:42.704Z" },
+    { url = "https://files.pythonhosted.org/packages/79/98/679de17c2caa4fd3b0b4386ecf7377301702cb0afb22930a07c142fcb1d8/xgboost-3.2.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:99b4a6bbcb47212fec5cf5fbe12347215f073c08967431b0122cfbd1ee70312c", size = 131748579, upload-time = "2026-02-10T10:54:40.424Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/3d/1661dd114a914a67e3f7ab66fa1382e7599c2a8c340f314ad30a3e2b4d08/xgboost-3.2.0-py3-none-win_amd64.whl", hash = "sha256:0d169736fd836fc13646c7ab787167b3a8110351c2c6bc770c755ee1618f0442", size = 101681668, upload-time = "2026-02-10T10:59:31.202Z" },
+]
+
+[[package]]
+name = "xgboost"
+version = "3.4.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "nvidia-nccl-cu13", marker = "python_full_version >= '3.12' and sys_platform == 'linux'" },
+    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/a9/295320f741c5be4be996c73ee65a2a11852028c50daa7229adb0d61c330b/xgboost-3.4.1.tar.gz", hash = "sha256:6968a4c71efdfa859df0dfcad0d99211c95c28c4ffd6aecff46efff77d18026a", size = 1231819, upload-time = "2026-08-15T08:39:21.197Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/ea/0bdcd374241a86f1986e87e272516f0a70d841c3aa86aa9ca167fb651573/xgboost-3.4.1-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:1ea15f15f661825b6a67d87674fb9604a1abb38dd0d4c5cf0486fc85f5203e83", size = 2541584, upload-time = "2026-08-15T08:38:48.484Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/94/e5c37a8972ad780edc1d8459d1931356344ca133f7f99ba9cfda516b5bba/xgboost-3.4.1-py3-none-macosx_12_0_arm64.whl", hash = "sha256:a7afd7dbace0951c93aa85ffe046e54bc40893f5b51cd3e7991eb157bf9c7c7c", size = 2365501, upload-time = "2026-08-15T08:38:52.366Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/11/4ff1f36ca5c32c642c71c88bec1508ee98b2c3b1e9eb169e8c82de303522/xgboost-3.4.1-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:7faaf99de26719c22bfae883a02bd56b5a3c2203122616e563cc72b7191b5c96", size = 57196172, upload-time = "2026-08-15T08:39:03.288Z" },
+    { url = "https://files.pythonhosted.org/packages/99/c7/bd05c5c430feb347aa040fcc8870135d70b256718deee9bc7d2ca74a77ff/xgboost-3.4.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:6adf2afa396da2ae8ed30295b50b99d4712eed9a6e0ce6cfe069290e4335e51f", size = 57615456, upload-time = "2026-08-15T08:39:09.983Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3c/925394671f6a1668e2a71886de66e80be694eaf37f615cec74eefaf43107/xgboost-3.4.1-py3-none-win_amd64.whl", hash = "sha256:2d30fa513673101f542fdcbd18f30c8f96c064046f798635ac08663e9969f81b", size = 48942686, upload-time = "2026-08-15T08:39:16.182Z" },
+    { url = "https://files.pythonhosted.org/packages/90/2f/f2fbe984ca095709fd246546125e78834740f347e3aa7561a22a1e928510/xgboost-3.4.1-py3-none-win_arm64.whl", hash = "sha256:e9312b30e5679d27c1d8b9ee97e092b964d960a672d5d406d9fb3cd0845c9797", size = 2094178, upload-time = "2026-08-15T08:39:19.308Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2818,7 +2818,7 @@ requires-dist = [
     { name = "ray", extras = ["data", "train"], marker = "sys_platform != 'win32' and extra == 'ray'", specifier = ">=2.56" },
     { name = "scikit-learn" },
     { name = "utilsforecast", specifier = ">=0.2.9" },
-    { name = "xgboost", marker = "sys_platform != 'win32' and extra == 'ray'" },
+    { name = "xgboost", marker = "sys_platform != 'win32' and extra == 'ray'", specifier = ">=2.1.4" },
     { name = "xgboost", marker = "extra == 'dask'" },
     { name = "xgboost", marker = "extra == 'spark'" },
 ]


### PR DESCRIPTION
Closes #713.

## Summary

`DistributedMLForecast.fit` has been broken on ray >=2.56 for every user; CI only looked green because the workflow set an env var that users don't have. The fix is to move the ray models off the unmaintained `lightgbm_ray` / `xgboost_ray` onto `ray.train`, because none of the workarounds can be applied from inside `fit()`.

Four things land here:

1. **The fix** — `RayLGBMForecast` / `RayXGBForecast` train via `LightGBMTrainer` / `XGBoostTrainer`. Constructors and `model_` are unchanged.
2. **Hardening** — the placement-group leak that turned this one-line dtype error into a 6-hour CI job is gone, with a `--timeout` and a conftest reclaim as backstops.
3. **ray on python 3.14** — the marker gate is removed, so ubuntu 3.14 now runs the ray suite for the first time.
4. **Cheaper tests and a re-cut xgboost bound** — the ray suite goes from ~14m40s to under 2m, and `xgboost>=2.0.0,<2.1.0` (a `xgboost_ray` artefact) becomes `xgboost>=2.1.4`.

Details below.

## The bug

Since ray 2.56, `Dataset.to_pandas` yields `pd.ArrowDtype` columns. LightGBM's input validation (`_check_for_bad_pandas_dtypes`) whitelists dtypes before handing a buffer to the C++ side and rejects anything it doesn't recognise, so every engineered feature column is refused inside the training actor and `DistributedMLForecast.fit` fails for any user on ray's default configuration.

The user-visible error was useless — `RuntimeError: A Ray actor died during training` — with the real `ValueError: pandas dtypes must be int, float or bool` only visible in the dead actor's worker log.

XGBoost is unaffected: `xgb.DMatrix` accepts arrow-backed pandas natively. This is a LightGBM-only bug.

CI was only green because the workflow set `RAY_DATA_ENABLE_ARROW_BACKED_PANDAS_CONVERSION=0`, which did nothing for actual users.

## Why the fixes proposed in the issue don't work

All three routes are dead ends, which is what drives the approach here:

- **Casting the dataset before `RayDMatrix`** (option 1) doesn't help: the arrow-to-pandas conversion happens *inside* the training actor, not on the driver, so blocks still arrive as `double[pyarrow]`. Forcing pandas blocks via `map_batches(batch_format="pandas")` doesn't change that either.
- **Setting `DataContext.enable_arrow_backed_pandas_conversion = False`** (option 2) doesn't reach `lightgbm_ray`'s actors, which get a fresh default context.
- **The env var** only takes effect when set *before* `ray.init`. mlforecast inside `fit()` always runs after the user's cluster already exists, so it can never be a library-side fix — only advice we'd have to put in the docs.

That leaves no clean way to fix this while staying on `lightgbm_ray`.

## The change

The ray models move to `ray.train`, which is the maintained API (`lightgbm_ray` and `xgboost_ray` are both unmaintained) and, critically, puts the dtype conversion in a train loop we own — where ray's own `normalize_pandas_for_lightgbm` handles it:

- New `RayForecastBase` holds the trainer plumbing; `RayLGBMForecast` / `RayXGBForecast` mix it into `LGBMRegressor` / `XGBRegressor` and build a `LightGBMTrainer` / `XGBoostTrainer` instead of subclassing `RayLGBMRegressor` / `RayXGBRegressor`.
- The train loop builds and fits the library's own estimator in the worker and checkpoints it, as `lightgbm.dask._train_part` does, so `model_` is the estimator that was fitted rather than one rebuilt from native params. That keeps every parameter translation — aliases included — inside the library, and keeps the booster's `evals_result_` and the user's arguments on the way back. The checkpoint carries ray's standard booster artifact alongside it, so `RayTrainReportCallback.get_model` still works on the result.
- LightGBM's network params (`tree_learner="data_parallel"` plus `get_network_params()`) are passed explicitly. Ray's `LightGBMConfig` only stashes them in a per-worker global, so without them each worker trains an independent model on `1/num_workers` of the data and rank 0's is the one checkpointed, silently. XGBoost needs no equivalent: `XGBoostConfig` wraps the loop in a `CommunicatorContext`.
- `_fit`'s ray branch drops `RayDMatrix` and calls `clone(model).fit(prep_selected, target_col=target_col)`.
- `RAY_INSTALLED` now keys off `ray.data` rather than importing `lightgbm_ray`.
- `model_` is still a local `LGBMRegressor` / `XGBRegressor`, so `predict`, `save` and `to_local` are untouched.
- Dependencies: `lightgbm_ray` and `xgboost_ray` out; `ray[data,train]>=2.56` in (2.56 is where `normalize_pandas_for_lightgbm` landed), plus an explicit `lightgbm>=4.6`, which previously arrived only as a `lightgbm_ray` transitive dependency.

### Compatibility

Constructors are unchanged: booster params are still passed as kwargs, with the ray-specific `num_workers` / `resources_per_worker` / `storage_path` keyword-only so they can't collide. Both classes are still `LGBMRegressor` / `XGBRegressor` subclasses, as on `main`, so `isinstance` checks and `clone()` keep working, and the parameter handling is the library's throughout rather than ours.

One thing changes for anyone reaching past the documented surface: `RayParams` is no longer accepted (nothing in the repo or docs ever passed it).

One behavioural change is worth calling out on its own: **the worker count no longer comes from `n_jobs`.** Both old wrappers derived it via `RayParams(num_actors=n_jobs)`, falling back to 1. The default is unchanged, but anyone who set `n_jobs=8` to get 8 actors now gets a single worker with `n_jobs` as its thread count — they want `num_workers=8`.

`resources_per_worker` is the CPU knob: it decides how many CPUs each worker gets and therefore how many threads the booster can use. Left unset it defaults to the cluster's CPUs split evenly across the workers, which is what `xgboost_ray._autodetect_resources` gave the actors, so a default fit keeps the parallelism it had on `main`. `n_jobs` can only lower the count below that share; `model_` carries the requested value rather than the clamp, since it's shipped to the forecasting workers and returned by `to_local`.

`storage_path` is new, and defaults to a temporary directory that's discarded once the fitted model has been read back. Ray's own default would otherwise leave a run under `~/ray_results` per model per fit, which neither old wrapper did; as with ray's default, a local path is single-node, so point it at shared storage on a multi-node cluster.

## Why this bug cost a day of CI, and what stops that recurring

`lightgbm_ray` leaks its placement group when its `fit` raises — on *any* exception, not just this one. The leaked group keeps holding the cluster's CPUs, so the *next* test's `ray.data` call blocks forever rather than failing. That is how a one-line dtype error became a 6-hour job on every ubuntu runner.

Ray Train tears its placement group down on both success and failure, and surfaces the real traceback via `WorkerGroupError`. As backstops:

- CI gets `--timeout=600` (`pytest-timeout` added to the dev group, which both install steps use).
- The ray conftest reclaims leaked placement groups between tests. It snapshots the table before each test and keeps what was already there, so a group a session- or module-scoped fixture legitimately holds isn't taken with them.
- The conftest's linux-only skip is overridable with `MLFORECAST_FORCE_RAY_TESTS=1`, so the suite can be run on macOS while developing.

The env-var workaround is removed from the workflow here, so CI now covers the supported configuration.

## ray on python 3.14

The ray extra was marker-gated to `python_version < '3.14'` and the conftest skipped the suite there. That gate is worth noting in this context: **ubuntu 3.14 was the only ubuntu job that stayed green while every other one hung — precisely because it was the one job not installing ray at all.** That green was masking the bug, not disproving it.

`ray` ships cp314 wheels as of 2.56.1, and `fugue[ray]`, `lightgbm` and `xgboost` all resolve on 3.14, so the gate is removed. The ubuntu 3.14 job now exercises the ray suite for the first time, which is a genuinely new path in CI.

## Tests

New `tests/distributed_ray/test_ray_models.py` covers:

- that LightGBM trains on the whole dataset across workers rather than on rank 0's shard — a constant feature and a split target, so the prediction is exactly the mean of whatever the model actually saw. It fails without the network params;
- that `model_` is the estimator the worker fitted: the user's `n_estimators` / `random_state` survive, `evals_result_` is populated, and its predictions match the booster's;
- that lightgbm's parameter aliases are honoured (`application`, `num_iterations`), which is what handing the translation back to the library buys;
- that xgboost keeps `random_state` and doesn't carry the ray callback back into `DistributedMLForecast.save`'s pickle;
- the `n_estimators=100` default, and that each worker gets a share of the cluster's CPUs;
- that a fit writes nothing to `~/ray_results` and honours an explicit `storage_path`;
- placement-group reclaim, in both directions: a leaked group is freed, a pre-existing one is left alone;
- that `clone()` preserves booster params — sklearn's introspection reads the subclass' signature, which only names the ray arguments, so `RayLGBMForecast._get_param_names` folds in `LGBMRegressor`'s. Without it the `clone()` in `_fit` would silently drop every parameter the user passed.

The skips for python < 3.10 are gone from this directory: `requires-python` is `>=3.10` and the CI matrix starts there, so none of them could fire.

### Runtime

These tests assert that predictions match across code paths, never model quality, so training 100 boosting rounds was pure cost — roughly 90% of the suite's runtime. They now pass `n_estimators=5`. The forecast test's data is also smaller: 20 series of 100-200 points with the lag transform at 20, rather than 100 series of 500-1000 with it at 335.

Together those take the ray suite from ~14m40s to under 2m, with every assertion unchanged. Note the split: the boosting rounds were nearly all of the win, and the data reduction only moved the heaviest test from ~28s to ~21s, because what remains is per-test ray orchestration rather than data volume. `--timeout=600` has a wide margin at these durations.

## Re-cutting the xgboost bound

`xgboost>=2.0.0,<2.1.0` existed for `xgboost_ray` compat, which is gone. The ray extra now takes `xgboost>=2.1.4`: `RayXGBForecast` mixes `RayForecastBase` into `XGBRegressor`, and `XGBModel.get_params` only survives walking into the mixin through the "if the immediate parent defines `get_params()`, use it; otherwise skip to `__bases__[1]`" fallback, which landed in 2.1.4. Below that it raises `AttributeError`, and `DistributedMLForecast._fit` clones the model, so it's a hard failure at fit time. It resolves to 3.4.1 on python >=3.12 and 3.2.0 below it.

Worth knowing this is **not** a ray-only change: the lock resolves one xgboost per python version, so that bound was constraining dask, spark and the local tests too. The APIs all three models rely on are unchanged across the major bump — the `save_raw("ubj")` -> `load_model` round trip and `xgboost.dask.DaskXGBRegressor`.

One cost to be aware of: xgboost 3.x depends on `nvidia-nccl` on linux (~250MB on 3.12+, ~340MB below), so the ubuntu jobs download that once per lock change. macOS and Windows are unaffected — the dependency is marked `sys_platform == 'linux'`.
