### PR TITLE
docs: fix documented defaults that disagree with the signatures

### DIFF
--- a/mlforecast/distributed/forecast.py
+++ b/mlforecast/distributed/forecast.py
@@ -81,7 +81,7 @@ class DistributedMLForecast:
 
         Args:
             models (regressor or list of regressors): Models that will be trained and used to compute the forecasts.
-            freq (str or int, optional): Pandas offset alias, e.g. 'D', 'W-THU' or integer denoting the frequency of the series. Defaults to None.
+            freq (str or int): Pandas offset alias, e.g. 'D', 'W-THU' or integer denoting the frequency of the series.
             lags (list of int, optional): Lags of the target to use as features. Defaults to None.
             lag_transforms (dict of int to list of functions, optional): Mapping of target lags to their transformations. Defaults to None.
             date_features (list of str or callable, optional): Features computed from the dates. Can be pandas date attributes or functions that will take the dates as input.

--- a/mlforecast/forecast.py
+++ b/mlforecast/forecast.py
@@ -456,7 +456,7 @@ class MLForecast:
                 Each template must include exactly one '{h}' placeholder (1-indexed), for example: ['feature_h{h}'].
                 Acts as shorthand for `horizon_features` and is only supported when using `max_horizon` or `horizons`. Defaults to None.
             return_X_y (bool): Return a tuple with the features and the target. If False will return a single dataframe. Defaults to False.
-            as_numpy (bool): Cast features to numpy array. Only works for `return_X_y=True`. Defaults to True.
+            as_numpy (bool): Cast features to numpy array. Only works for `return_X_y=True`. Defaults to False.
             weight_col (str, optional): Column that contains the sample weights. Defaults to None.
             validate_data (bool): Run data quality validations before preprocessing. Warns about missing dates and raises on duplicate rows. Defaults to True.
 
@@ -1159,7 +1159,7 @@ class MLForecast:
                 Acts as shorthand for `horizon_features` and is only supported when using `max_horizon` or `horizons`. Defaults to None.
             prediction_intervals (PredictionIntervals, optional): Configuration to calibrate prediction intervals (Conformal Prediction). Defaults to None.
             fitted (bool): Save in-sample predictions. Defaults to False.
-            as_numpy (bool): Cast features to numpy array. Defaults to True.
+            as_numpy (bool): Cast features to numpy array. Defaults to False.
             weight_col (str, optional): Column that contains the sample weights. Defaults to None.
             models_fit_kwargs (dict, optional): Keyword arguments for each model's fit method. Defaults to None.
             validate_data (bool): Run data quality validations before fitting. Warns about missing dates and raises on duplicate rows. Defaults to True.
@@ -1912,7 +1912,7 @@ class MLForecast:
             level (list of ints or floats, optional): Confidence levels between 0 and 100 for prediction intervals. Defaults to None.
             input_size (int, optional): Maximum training samples per serie in each window. If None, will use an expanding window. Defaults to None.
             fitted (bool): Store the in-sample predictions. Defaults to False.
-            as_numpy (bool): Cast features to numpy array. Defaults to True.
+            as_numpy (bool): Cast features to numpy array. Defaults to False.
             weight_col (str, optional): Column that contains the sample weights. Defaults to None.
             validate_data (bool): Run data quality validations on the full dataset before cross-validation. Warns about missing dates and raises on duplicate rows. Defaults to True.
 


### PR DESCRIPTION
Four docstrings state defaults that don't match their signatures. Docs only, no behaviour change.

### `as_numpy` documented as `True`, actually `False`

`MLForecast.preprocess`, `MLForecast.fit` and `MLForecast.cross_validation` all declare:

```python
as_numpy: bool = False,
```

but each documents it as:

```
as_numpy (bool): Cast features to numpy array. Defaults to True.
```

So the docs say features are cast to a numpy array by default when they aren't. `MLForecast.predict` is the one that's already right — it takes `Optional[bool] = None` and documents "Defaults to None" — so only these three needed changing.

### `DistributedMLForecast.freq` documented as optional, actually required

```python
def __init__(
    self,
    models,
    freq: Freq,          # required, no default
    ...
```

```
freq (str or int, optional): Pandas offset alias, e.g. 'D', 'W-THU' or integer denoting the frequency of the series. Defaults to None.
```

`freq` has no default, so following the docs and omitting it raises `TypeError`. `MLForecast.__init__` documents the same required `freq: Freq` without "optional" and without a "Defaults to" clause:

```
freq (str or int or pd.offsets.BaseOffset): Pandas offset, pandas offset alias, e.g. 'D', 'W-THU' or integer denoting the frequency of the series.
```

so this just brings the distributed class in line with its sibling. The `models` entry immediately above it already follows that convention.

Checked with `ruff check` and `ruff format --check` on both changed files — clean.
