### PR TITLE
fix: preserve target transform state in cross-validation

### DIFF
--- a/mlforecast/core.py
+++ b/mlforecast/core.py
@@ -7,6 +7,7 @@ import reprlib
 import warnings
 from collections import Counter, OrderedDict
 from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 from typing import (
     Any,
@@ -251,6 +252,197 @@ def _to_native_index(values, *, df):
     if isinstance(df, pd.DataFrame):
         return pd.Index(values)
     return pl_Series(values)
+
+
+@dataclass
+class _MatchedUpdate:
+    df: DataFrame
+    uids: Any
+    matched_ids: Any
+
+
+@dataclass
+class _PreparedUpdate(_MatchedUpdate):
+    """Backend-normalized inputs shared by all update paths."""
+
+    id_counts: DataFrame
+    sizes: DataFrame
+    new_groups: Any
+
+
+def _match_update_data(
+    df: DataFrame,
+    *,
+    uids: Any,
+    id_col: str,
+    time_col: str,
+) -> _MatchedUpdate:
+    """Match update IDs to the fitted backend and sort the rows."""
+    native_uids = _index_to_series(uids)
+    native_uids, matched_ids = ufp.match_if_categorical(native_uids, df[id_col])
+    df = ufp.copy_if_pandas(df, deep=False)
+    df = ufp.assign_columns(df, id_col, matched_ids)
+    df = ufp.sort(df, by=[id_col, time_col])
+    return _MatchedUpdate(df=df, uids=native_uids, matched_ids=matched_ids)
+
+
+def _prepare_update_data(matched: _MatchedUpdate, *, id_col: str) -> _PreparedUpdate:
+    """Compute group sizes and detect series introduced by an update."""
+    id_counts = ufp.counts_by_id(matched.df, id_col)
+    try:
+        sizes = ufp.join(matched.uids, id_counts, on=id_col, how="outer_coalesce")
+    except (KeyError, ValueError):
+        # pandas raises key error, polars before coalesce raises value error
+        sizes = ufp.join(matched.uids, id_counts, on=id_col, how="outer")
+    sizes = ufp.fill_null(sizes, {"counts": 0})
+    sizes = ufp.sort(sizes, by=id_col)
+    new_groups = ~ufp.is_in(sizes[id_col], matched.uids)
+    return _PreparedUpdate(
+        df=matched.df,
+        uids=matched.uids,
+        matched_ids=matched.matched_ids,
+        id_counts=id_counts,
+        sizes=sizes,
+        new_groups=new_groups,
+    )
+
+
+def _updated_last_dates(
+    df: DataFrame,
+    *,
+    uids: Any,
+    sizes: DataFrame,
+    last_dates: Any,
+    id_col: str,
+    time_col: str,
+) -> Any:
+    """Advance each fitted series' last date from a prepared update."""
+    current_col = "_mlforecast_current_last_date"
+    while current_col in df.columns:
+        current_col = f"_{current_col}"
+    updated = ufp.group_by_agg(df, id_col, {time_col: "max"})
+    updated = ufp.join(sizes, updated, on=id_col, how="left")
+    current = type(df)({id_col: uids, current_col: last_dates})
+    updated = ufp.join(updated, current, on=id_col, how="left")
+    updated = ufp.fill_null(updated, {time_col: updated[current_col]})
+    updated = ufp.sort(updated, by=id_col)
+    values = ufp.cast(updated[time_col], last_dates.dtype)
+    return _to_native_index(values, df=df)
+
+
+@dataclass
+class _TargetTransformState:
+    """Target-only state advanced between frozen-model CV windows."""
+
+    transforms: List[TargetTransform]
+    uids: Any
+    last_dates: Any
+    id_col: str
+    time_col: str
+    target_col: str
+    target_dtype: np.dtype
+
+    @classmethod
+    def from_time_series(cls, ts: "TimeSeries") -> "_TargetTransformState":
+        """Copy only state required to advance and replay target transforms."""
+        if ts.target_transforms is None:
+            raise ValueError("No fitted target transforms are available.")
+        return cls(
+            transforms=copy.deepcopy(ts.target_transforms),
+            uids=copy.deepcopy(ts.uids),
+            last_dates=copy.deepcopy(ts.last_dates),
+            id_col=ts.id_col,
+            time_col=ts.time_col,
+            target_col=ts.target_col,
+            target_dtype=ts.ga.data.dtype,
+        )
+
+    def new_observations(self, train: DataFrame) -> DataFrame:
+        """Return rows in ``train`` that are newer than this state."""
+        last_date_col = "_mlforecast_last_date"
+        while last_date_col in train.columns:
+            last_date_col = f"_{last_date_col}"
+        last_dates = type(train)(
+            {self.id_col: self.uids, last_date_col: self.last_dates}
+        )
+        updates = ufp.join(train, last_dates, on=self.id_col, how="left")
+        unknown = (
+            nw.from_native(updates[last_date_col], series_only=True)
+            .is_null()
+            .to_native()
+        )
+        if unknown.any():
+            unknown_ids = ufp.filter_with_mask(updates[self.id_col], unknown)
+            raise ValueError(
+                "Can not update target_transforms with new series: "
+                f"{list(unknown_ids)!r}."
+            )
+        updates = ufp.filter_with_mask(
+            updates, updates[self.time_col] > updates[last_date_col]
+        )
+        return ufp.drop_columns(updates, last_date_col)
+
+    def update(self, df: DataFrame) -> None:
+        """Advance target transforms without creating feature state."""
+        validate_format(df, self.id_col, self.time_col, self.target_col)
+        matched = _match_update_data(
+            df,
+            uids=self.uids,
+            id_col=self.id_col,
+            time_col=self.time_col,
+        )
+        prepared = _prepare_update_data(matched, id_col=self.id_col)
+        if prepared.new_groups.any():
+            raise ValueError("Can not update target_transforms with new series.")
+        df = prepared.df
+        values = df[self.target_col].to_numpy().astype(self.target_dtype, copy=False)
+        has_grouped_transforms = any(
+            isinstance(tfm, _BaseGroupedArrayTargetTransform) for tfm in self.transforms
+        )
+        if has_grouped_transforms:
+            indptr = np.append(0, prepared.sizes["counts"]).cumsum()
+        for tfm in self.transforms:
+            if isinstance(tfm, _BaseGroupedArrayTargetTransform):
+                ga = tfm.update(GroupedArray(values, indptr))
+                df = ufp.assign_columns(df, self.target_col, ga.data)
+            else:
+                df = tfm.update(df)
+            values = df[self.target_col].to_numpy()
+
+        self.last_dates = _updated_last_dates(
+            df,
+            uids=prepared.uids,
+            sizes=prepared.sizes,
+            last_dates=self.last_dates,
+            id_col=self.id_col,
+            time_col=self.time_col,
+        )
+
+    def replay_history(
+        self, df: DataFrame, store_fitted: bool
+    ) -> Tuple[DataFrame, List[TargetTransform]]:
+        """Replay a bounded history with frozen fitted parameters."""
+        transformed = ufp.sort(df, by=[self.id_col, self.time_col])
+        transformed = ufp.copy_if_pandas(transformed, deep=False)
+        uids, _, values, indptr, _ = ufp.process_df(
+            transformed, self.id_col, self.time_col, self.target_col
+        )
+        if list(uids) != list(self.uids):
+            raise ValueError("History must contain exactly the fitted series.")
+        if values.ndim == 2:
+            values = values[:, 0]
+        transforms = copy.deepcopy(self.transforms)
+        ga = GroupedArray(values, indptr)
+        for tfm in transforms:
+            if hasattr(tfm, "store_fitted"):
+                tfm.store_fitted = store_fitted
+            if isinstance(tfm, _BaseGroupedArrayTargetTransform):
+                ga = tfm._transform_history(ga)
+                transformed = ufp.assign_columns(transformed, self.target_col, ga.data)
+            else:
+                transformed = tfm._transform_history(transformed)
+                ga.data = transformed[self.target_col].to_numpy()
+        return transformed, transforms
 
 
 class TimeSeries:
@@ -682,11 +874,62 @@ class TimeSeries:
         keep_last_n: Optional[int] = None,
         weight_col: Optional[str] = None,
     ) -> "TimeSeries":
-        """Save the series values, ids and last dates."""
+        """Validate raw targets and initialize the time-series state."""
         validate_format(df, id_col, time_col, target_col)
         validate_freq(df[time_col], self.freq)
         if ufp.is_nan_or_none(df[target_col]).any():
             raise ValueError(f"{target_col} column contains null values.")
+        return self._fit_core(
+            df=df,
+            id_col=id_col,
+            time_col=time_col,
+            target_col=target_col,
+            static_features=static_features,
+            keep_last_n=keep_last_n,
+            weight_col=weight_col,
+        )
+
+    def _fit_transformed(
+        self,
+        df: DataFrame,
+        id_col: str,
+        time_col: str,
+        target_col: str,
+        static_features: Optional[List[str]] = None,
+        keep_last_n: Optional[int] = None,
+        weight_col: Optional[str] = None,
+    ) -> "TimeSeries":
+        """Initialize state from a target transformed by a fitted transform.
+
+        Target transforms can introduce leading nulls (for example,
+        differencing), so this internal path intentionally omits the raw-target
+        null check while preserving all structural validation.
+        """
+        if self.target_transforms is not None:
+            raise ValueError("Transformed target data requires target_transforms=None.")
+        validate_format(df, id_col, time_col, target_col)
+        validate_freq(df[time_col], self.freq)
+        return self._fit_core(
+            df=df,
+            id_col=id_col,
+            time_col=time_col,
+            target_col=target_col,
+            static_features=static_features,
+            keep_last_n=keep_last_n,
+            weight_col=weight_col,
+        )
+
+    def _fit_core(
+        self,
+        df: DataFrame,
+        id_col: str,
+        time_col: str,
+        target_col: str,
+        static_features: Optional[List[str]] = None,
+        keep_last_n: Optional[int] = None,
+        weight_col: Optional[str] = None,
+    ) -> "TimeSeries":
+        """Save the series values, ids and last dates."""
         self.id_col = id_col
         self.target_col = target_col
         self.time_col = time_col
@@ -802,6 +1045,66 @@ class TimeSeries:
         self.features_order_ = [f for f in self.features_order_ if f not in to_exclude]
         self._build_pooled_states(df, sorted_df, ga)
         return self
+
+    def _copy_config(self) -> "TimeSeries":
+        """Create an unfitted instance with the same feature configuration."""
+        return TimeSeries(
+            freq=self.freq,
+            lags=self.lags,
+            lag_transforms=self.lag_transforms,
+            date_features=self.date_features,
+            num_threads=self.num_threads,
+            target_transforms=None,
+            lag_transforms_namer=self.lag_transforms_namer,
+            date_features_as_dummies=self.date_features_as_dummies,
+            drop_auxiliary_columns=self.drop_auxiliary_columns,
+        )
+
+    def _build_from_transformed_history(
+        self,
+        transformed: DataFrame,
+        target_transforms: List[TargetTransform],
+        static_features: Optional[List[str]],
+        dropna: bool,
+        keep_last_n: Optional[int],
+        max_horizon: Optional[int],
+        horizons: Optional[List[int]],
+        as_numpy: bool,
+        weight_col: Optional[str],
+        materialize_fitted: bool,
+    ) -> Tuple["TimeSeries", Optional[DataFrame]]:
+        """Build bounded feature state from already fitted target transforms."""
+        window = self._copy_config()
+        window._fit_transformed(
+            df=transformed,
+            id_col=self.id_col,
+            time_col=self.time_col,
+            target_col=self.target_col,
+            static_features=static_features,
+            keep_last_n=keep_last_n,
+            weight_col=weight_col,
+        )
+        window.target_transforms = target_transforms
+        window.horizon_features_ = copy.deepcopy(self.horizon_features_)
+        if materialize_fitted:
+            prep = window._transform(
+                df=transformed,
+                dropna=dropna,
+                max_horizon=max_horizon,
+                horizons=horizons,
+                return_X_y=False,
+                as_numpy=False,
+            )
+        else:
+            window._initialize_lag_transform_states()
+            window._apply_keep_last_n()
+            del window._restore_idxs, window._sort_idxs
+            window._horizons, window.max_horizon = _validate_horizon_params(
+                max_horizon, horizons
+            )
+            prep = None
+        window.as_numpy = as_numpy
+        return window, prep
 
     def _build_pooled_states(self, df, sorted_df, ga) -> None:
         """Aggregate the panel into per-bucket channels, one state per key.
@@ -2062,11 +2365,15 @@ class TimeSeries:
             validate_new_data: If True, validate continuity, start dates, and frequency.
         """
         validate_format(df, self.id_col, self.time_col, self.target_col)
-        uids = _index_to_series(self.uids)
-        uids, new_ids = ufp.match_if_categorical(uids, df[self.id_col])
-        df = ufp.copy_if_pandas(df, deep=False)
-        df = ufp.assign_columns(df, self.id_col, new_ids)
-        df = ufp.sort(df, by=[self.id_col, self.time_col])
+        matched = _match_update_data(
+            df,
+            uids=self.uids,
+            id_col=self.id_col,
+            time_col=self.time_col,
+        )
+        df = matched.df
+        uids = matched.uids
+        new_ids = matched.matched_ids
         values = df[self.target_col].to_numpy()
         values = values.astype(self.ga.data.dtype, copy=False)
         self._check_aligned_ends()
@@ -2091,28 +2398,23 @@ class TimeSeries:
                 )
         if validate_new_data:
             self._validate_new_df(df=df)
-        id_counts = ufp.counts_by_id(df, self.id_col)
-        try:
-            sizes = ufp.join(uids, id_counts, on=self.id_col, how="outer_coalesce")
-        except (KeyError, ValueError):
-            # pandas raises key error, polars before coalesce raises value error
-            sizes = ufp.join(uids, id_counts, on=self.id_col, how="outer")
-        sizes = ufp.fill_null(sizes, {"counts": 0})
-        sizes = ufp.sort(sizes, by=self.id_col)
-        new_groups = ~ufp.is_in(sizes[self.id_col], uids)
-        last_dates = ufp.group_by_agg(df, self.id_col, {self.time_col: "max"})
-        last_dates = ufp.join(sizes, last_dates, on=self.id_col, how="left")
-        curr_last_dates = type(df)({self.id_col: uids, "_curr": self.last_dates})
-        last_dates = ufp.join(last_dates, curr_last_dates, on=self.id_col, how="left")
-        last_dates = ufp.fill_null(last_dates, {self.time_col: last_dates["_curr"]})
-        last_dates = ufp.sort(last_dates, by=self.id_col)
-        self.last_dates = ufp.cast(last_dates[self.time_col], self.last_dates.dtype)
-        self.uids = ufp.sort(sizes[self.id_col])
-        self.uids = _to_native_index(self.uids, df=df)
-        self.last_dates = _to_native_index(self.last_dates, df=df)
+        prepared = _prepare_update_data(matched, id_col=self.id_col)
+        id_counts = prepared.id_counts
+        sizes = prepared.sizes
+        new_groups = prepared.new_groups
+        if new_groups.any() and self.target_transforms is not None:
+            raise ValueError("Can not update target_transforms with new series.")
+        self.last_dates = _updated_last_dates(
+            df,
+            uids=uids,
+            sizes=sizes,
+            last_dates=self.last_dates,
+            id_col=self.id_col,
+            time_col=self.time_col,
+        )
         if new_groups.any():
-            if self.target_transforms is not None:
-                raise ValueError("Can not update target_transforms with new series.")
+            self.uids = _to_native_index(ufp.sort(sizes[self.id_col]), df=df)
+        if new_groups.any():
             new_ids = ufp.filter_with_mask(sizes[self.id_col], new_groups)
             new_ids_df = ufp.filter_with_mask(df, ufp.is_in(df[self.id_col], new_ids))
             new_ids_counts = ufp.counts_by_id(new_ids_df, self.id_col)

--- a/mlforecast/forecast.py
+++ b/mlforecast/forecast.py
@@ -1969,6 +1969,12 @@ class MLForecast:
                         ufp.assign_columns(self.fcst_fitted_values_, "fold", i_window)
                     )
             if fitted and not should_fit:
+                prediction_ts = None
+                if self.ts.target_transforms is not None:
+                    # `preprocess` refits target transforms. Run it on a copy so
+                    # the state fitted together with the frozen models is preserved.
+                    prediction_ts = self.ts
+                    self.ts = copy.deepcopy(self.ts)
                 if self.ts.target_transforms is not None:
                     for tfm in self.ts.target_transforms:
                         if hasattr(tfm, "store_fitted"):
@@ -2015,6 +2021,8 @@ class MLForecast:
                 )
                 fitted_values = ufp.assign_columns(fitted_values, "fold", i_window)
                 cv_fitted_values.append(fitted_values)
+                if prediction_ts is not None:
+                    self.ts = prediction_ts
             static = [c for c in self.ts.static_features_.columns if c != id_col]
             dynamic = [
                 c
@@ -2027,11 +2035,28 @@ class MLForecast:
                 )
             else:
                 X_df = None
+            prediction_df = train if not should_fit else None
+            if not should_fit and self.ts.target_transforms is not None:
+                # Keep the transforms fitted alongside the frozen models and only
+                # advance state that depends on the latest observed targets.
+                last_dates = type(train)(
+                    {
+                        id_col: self.ts.uids,
+                        "_last_date": self.ts.last_dates,
+                    }
+                )
+                updates = ufp.join(train, last_dates, on=id_col, how="left")
+                updates = ufp.filter_with_mask(
+                    updates, updates[time_col] > updates["_last_date"]
+                )
+                updates = ufp.drop_columns(updates, "_last_date")
+                self.update(updates)
+                prediction_df = None
             y_pred = self.predict(
                 h=h,
                 before_predict_callback=before_predict_callback,
                 after_predict_callback=after_predict_callback,
-                new_df=train if not should_fit else None,
+                new_df=prediction_df,
                 level=level,
                 X_df=X_df,
             )

--- a/mlforecast/forecast.py
+++ b/mlforecast/forecast.py
@@ -4,6 +4,7 @@ __all__ = ["MLForecast"]
 import copy
 import warnings
 import re
+from contextlib import contextmanager
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -36,6 +37,7 @@ from mlforecast.core import (
     Models,
     TargetTransform,
     TimeSeries,
+    _TargetTransformState,
     _get_model_name,
     _name_models,
     _validate_horizon_params,
@@ -974,6 +976,16 @@ class MLForecast:
                 if hasattr(tfm, "fitted_"):
                     tfm.fitted_ = []
         return fitted_values
+
+    @contextmanager
+    def _use_time_series(self, ts: TimeSeries) -> Iterator[None]:
+        """Temporarily use scratch state and always restore fitted state."""
+        fitted_ts = self.ts
+        self.ts = ts
+        try:
+            yield
+        finally:
+            self.ts = fitted_ts
 
     def _compute_recursive_fitted_values_on_demand(
         self,
@@ -1926,6 +1938,8 @@ class MLForecast:
         results = []
         cv_models = []
         cv_fitted_values = []
+        target_state: Optional[_TargetTransformState] = None
+        has_non_refit_windows = n_windows > 1 and refit != 1
         splits = ufp.backtest_splits(
             df,
             n_windows=n_windows,
@@ -1964,65 +1978,87 @@ class MLForecast:
                         validate_data=False,
                     )
                 cv_models.append(self.models_)
+                target_state = (
+                    _TargetTransformState.from_time_series(self.ts)
+                    if has_non_refit_windows and self.ts.target_transforms is not None
+                    else None
+                )
                 if fitted:
                     cv_fitted_values.append(
                         ufp.assign_columns(self.fcst_fitted_values_, "fold", i_window)
                     )
+            window_ts: Optional[TimeSeries] = None
+            window_prep: Optional[DFType] = None
+            if not should_fit and target_state is not None:
+                updates = target_state.new_observations(train)
+                if updates.shape[0] > 0:
+                    target_state.update(updates)
+                transformed_train, window_transforms = target_state.replay_history(
+                    train, store_fitted=fitted
+                )
+                window_ts, window_prep = self.ts._build_from_transformed_history(
+                    transformed=transformed_train,
+                    target_transforms=window_transforms,
+                    static_features=static_features,
+                    dropna=dropna,
+                    keep_last_n=keep_last_n,
+                    max_horizon=max_horizon,
+                    horizons=horizons,
+                    as_numpy=as_numpy,
+                    weight_col=weight_col,
+                    materialize_fitted=fitted,
+                )
             if fitted and not should_fit:
-                prediction_ts = None
-                if self.ts.target_transforms is not None:
-                    # `preprocess` refits target transforms. Run it on a copy so
-                    # the state fitted together with the frozen models is preserved.
-                    prediction_ts = self.ts
-                    self.ts = copy.deepcopy(self.ts)
-                if self.ts.target_transforms is not None:
-                    for tfm in self.ts.target_transforms:
-                        if hasattr(tfm, "store_fitted"):
-                            tfm.store_fitted = True
-                with warnings.catch_warnings():
-                    warnings.filterwarnings(
-                        "ignore",
-                        message="Pooled.*validate_data",
-                        category=UserWarning,
-                    )
-                    prep = self.preprocess(
-                        train,
+                if window_ts is None:
+                    with warnings.catch_warnings():
+                        warnings.filterwarnings(
+                            "ignore",
+                            message="Pooled.*validate_data",
+                            category=UserWarning,
+                        )
+                        prep = self.preprocess(
+                            train,
+                            id_col=id_col,
+                            time_col=time_col,
+                            target_col=target_col,
+                            static_features=static_features,
+                            dropna=dropna,
+                            keep_last_n=keep_last_n,
+                            max_horizon=max_horizon,
+                            horizons=horizons,
+                            horizon_features=horizon_features,
+                            horizon_feature_templates=horizon_feature_templates,
+                            return_X_y=False,
+                            weight_col=weight_col,
+                            validate_data=False,
+                        )
+                    assert not isinstance(prep, tuple)
+                    fitted_ts = self.ts
+                else:
+                    assert window_prep is not None
+                    prep = window_prep
+                    fitted_ts = window_ts
+                with self._use_time_series(fitted_ts):
+                    effective_max_horizon = self.ts.max_horizon
+                    base = prep[[id_col, time_col]]
+                    train_X, train_y = self._extract_X_y(prep, target_col, weight_col)
+                    if as_numpy:
+                        train_X = ufp.to_numpy(train_X)
+                    fitted_values = self._compute_fitted_values(
+                        base=base,
+                        X=train_X,
+                        y=train_y,
                         id_col=id_col,
                         time_col=time_col,
                         target_col=target_col,
-                        static_features=static_features,
-                        dropna=dropna,
-                        keep_last_n=keep_last_n,
-                        max_horizon=max_horizon,
-                        horizons=horizons,
-                        horizon_features=horizon_features,
-                        horizon_feature_templates=horizon_feature_templates,
-                        return_X_y=False,
+                        max_horizon=effective_max_horizon,
                         weight_col=weight_col,
-                        validate_data=False,
+                        original_df=(
+                            train if effective_max_horizon is not None else None
+                        ),
                     )
-                assert not isinstance(prep, tuple)
-                effective_max_horizon = self.ts.max_horizon
-                base = prep[[id_col, time_col]]
-                train_X, train_y = self._extract_X_y(prep, target_col, weight_col)
-                if as_numpy:
-                    train_X = ufp.to_numpy(train_X)
-                del prep
-                fitted_values = self._compute_fitted_values(
-                    base=base,
-                    X=train_X,
-                    y=train_y,
-                    id_col=id_col,
-                    time_col=time_col,
-                    target_col=target_col,
-                    max_horizon=effective_max_horizon,
-                    weight_col=weight_col,
-                    original_df=train if effective_max_horizon is not None else None,
-                )
                 fitted_values = ufp.assign_columns(fitted_values, "fold", i_window)
                 cv_fitted_values.append(fitted_values)
-                if prediction_ts is not None:
-                    self.ts = prediction_ts
             static = [c for c in self.ts.static_features_.columns if c != id_col]
             dynamic = [
                 c
@@ -2035,31 +2071,16 @@ class MLForecast:
                 )
             else:
                 X_df = None
-            prediction_df = train if not should_fit else None
-            if not should_fit and self.ts.target_transforms is not None:
-                # Keep the transforms fitted alongside the frozen models and only
-                # advance state that depends on the latest observed targets.
-                last_dates = type(train)(
-                    {
-                        id_col: self.ts.uids,
-                        "_last_date": self.ts.last_dates,
-                    }
+            prediction_df = train if not should_fit and window_ts is None else None
+            with self._use_time_series(window_ts or self.ts):
+                y_pred = self.predict(
+                    h=h,
+                    before_predict_callback=before_predict_callback,
+                    after_predict_callback=after_predict_callback,
+                    new_df=prediction_df,
+                    level=level,
+                    X_df=X_df,
                 )
-                updates = ufp.join(train, last_dates, on=id_col, how="left")
-                updates = ufp.filter_with_mask(
-                    updates, updates[time_col] > updates["_last_date"]
-                )
-                updates = ufp.drop_columns(updates, "_last_date")
-                self.update(updates)
-                prediction_df = None
-            y_pred = self.predict(
-                h=h,
-                before_predict_callback=before_predict_callback,
-                after_predict_callback=after_predict_callback,
-                new_df=prediction_df,
-                level=level,
-                X_df=X_df,
-            )
             y_pred = ufp.join(y_pred, cutoffs, on=id_col, how="left")
             result = ufp.join(
                 valid[[id_col, time_col, target_col]],

--- a/mlforecast/target_transforms.py
+++ b/mlforecast/target_transforms.py
@@ -38,6 +38,17 @@ class BaseTargetTransform(abc.ABC):
     def update(self, df: DataFrame) -> DataFrame:
         raise NotImplementedError
 
+    def _transform_history(self, df: DataFrame) -> DataFrame:
+        """Replay historical data using already fitted parameters.
+
+        Stateful transforms should rebuild any runtime state needed to invert
+        forecasts at the end of ``df``, without relearning fitted parameters.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} must implement _transform_history to support "
+            "cross_validation with frozen models."
+        )
+
     @staticmethod
     def stack(transforms: Sequence["BaseTargetTransform"]) -> "BaseTargetTransform":
         raise NotImplementedError
@@ -60,6 +71,13 @@ class _BaseGroupedArrayTargetTransform(abc.ABC):
 
     @abc.abstractmethod
     def update(self, ga: GroupedArray) -> GroupedArray: ...
+
+    def _transform_history(self, ga: GroupedArray) -> GroupedArray:
+        """Replay historical data using already fitted parameters."""
+        raise NotImplementedError(
+            f"{type(self).__name__} must implement _transform_history to support "
+            "cross_validation with frozen models."
+        )
 
     @abc.abstractmethod
     def fit_transform(self, ga: GroupedArray) -> GroupedArray: ...
@@ -121,6 +139,11 @@ class Differences(_BaseGroupedArrayTargetTransform):
             transformed = scaler.update(core_ga)
             core_ga = core_ga._with_data(transformed)
         return GroupedArray(transformed, ga.indptr)
+
+    def _transform_history(self, ga: GroupedArray) -> GroupedArray:
+        # Differences has no learned parameters. Rebuilding the scalers gives
+        # them tails aligned with the end of this history.
+        return self.fit_transform(ga)
 
     def inverse_transform(self, ga: GroupedArray) -> GroupedArray:
         core_ga = CoreGroupedArray(ga.data, ga.indptr, self.num_threads)
@@ -236,6 +259,24 @@ class AutoDifferences(_BaseGroupedArrayTargetTransform):
     def update(self, ga: GroupedArray) -> GroupedArray:
         core_ga = CoreGroupedArray(ga.data, ga.indptr, self.num_threads)
         return GroupedArray(self.scaler_.update(core_ga), ga.indptr)
+
+    def _transform_history(self, ga: GroupedArray) -> GroupedArray:
+        """Apply learned differencing decisions and rebuild inversion tails."""
+        core_ga = CoreGroupedArray(ga.data, ga.indptr, self.num_threads)
+        self.fitted_ = []
+        self.fitted_indptr_ = None
+        if self.store_fitted:
+            self.fitted_indptr_ = core_ga.indptr.copy()
+        self.scaler_.tails_ = []
+        transformed = core_ga.data.copy()
+        for differences in self._diffs_per_step(core_ga.indptr.dtype):
+            core_ga = core_ga._with_data(transformed)
+            if self.store_fitted:
+                self.fitted_.append(core_ga.data.copy())
+            tails_indptr: np.ndarray = np.append(0, differences.cumsum())
+            self.scaler_.tails_.append(core_ga._tails(tails_indptr))
+            transformed = core_ga._diffs(differences)
+        return GroupedArray(transformed, ga.indptr)
 
     def inverse_transform(self, ga: GroupedArray) -> GroupedArray:
         core_ga = CoreGroupedArray(ga.data, ga.indptr, self.num_threads)
@@ -379,6 +420,9 @@ class _BaseLocalScaler(_BaseGroupedArrayTargetTransform):
     scaler_factory: type
 
     def update(self, ga: GroupedArray) -> GroupedArray:
+        return self._transform_history(ga)
+
+    def _transform_history(self, ga: GroupedArray) -> GroupedArray:
         ga = CoreGroupedArray(ga.data, ga.indptr, self.num_threads)
         return GroupedArray(self.scaler_.transform(ga), ga.indptr)
 
@@ -458,6 +502,9 @@ class GlobalSklearnTransformer(BaseTargetTransform):
         return ufp.assign_columns(df, cols_to_transform, transformed)
 
     def update(self, df: DataFrame) -> DataFrame:
+        return self._transform_history(df)
+
+    def _transform_history(self, df: DataFrame) -> DataFrame:
         df = ufp.copy_if_pandas(df, deep=False)
         transformed = self.transformer_.transform(df[[self.target_col]].to_numpy())
         return ufp.assign_columns(df, self.target_col, transformed[:, 0])

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -18,13 +18,21 @@ from utilsforecast.feature_engineering import fourier, time_features
 from utilsforecast.processing import match_if_categorical
 
 from mlforecast import MLForecast
+from mlforecast.core import _TargetTransformState
 from mlforecast.lag_transforms import (
     ExpandingMean,
     ExponentiallyWeightedMean,
     RollingMean,
 )
 from mlforecast.lgb_cv import LightGBMCV
-from mlforecast.target_transforms import Differences, LocalStandardScaler
+from mlforecast.target_transforms import (
+    AutoDifferences,
+    AutoSeasonalDifferences,
+    AutoSeasonalityAndDifferences,
+    BaseTargetTransform,
+    Differences,
+    LocalStandardScaler,
+)
 from mlforecast.utils import (
     PredictionIntervals,
     generate_daily_series,
@@ -617,7 +625,8 @@ def test_cv_no_refit(setup_forecast_data):
 @pytest.mark.parametrize("engine", ["pandas", "polars"])
 @pytest.mark.parametrize("fitted", [False, True])
 @pytest.mark.parametrize("difference", [False, True])
-def test_cv_no_refit_preserves_target_transform_state(engine, fitted, difference):
+@pytest.mark.parametrize("refit", [False, 2])
+def test_cv_preserves_target_transform_state(engine, fitted, difference, refit):
     n = 100
     trend = np.arange(n, dtype=float)
     series = pd.DataFrame(
@@ -646,7 +655,7 @@ def test_cv_no_refit_preserves_target_transform_state(engine, fitted, difference
         h=2,
         step_size=1,
         static_features=[],
-        refit=False,
+        refit=refit,
         fitted=fitted,
     )
 
@@ -763,6 +772,204 @@ def test_cv_no_refit_fitted_values_preserve_target_transform_state():
     )
 
 
+@pytest.mark.parametrize(
+    "target_transform",
+    [
+        AutoDifferences(max_diffs=2),
+        AutoSeasonalDifferences(season_length=7, max_diffs=1),
+        AutoSeasonalityAndDifferences(max_season_length=7, max_diffs=1),
+    ],
+)
+def test_cv_no_refit_reuses_learned_auto_differences(target_transform):
+    """Scratch windows rebuild tails without relearning auto differences."""
+    n = 100
+    trend = np.arange(n, dtype=float)
+    series = pd.DataFrame(
+        {
+            "unique_id": "series",
+            "ds": pd.date_range("2025-01-01", periods=n, freq="D"),
+            "y": trend,
+            "trend": trend,
+        }
+    )
+    fcst = MLForecast(
+        models=LinearRegression(),
+        freq="D",
+        target_transforms=[target_transform],
+    )
+
+    cv = fcst.cross_validation(
+        series,
+        n_windows=3,
+        h=2,
+        static_features=[],
+        refit=False,
+        fitted=True,
+    )
+    fitted_values = fcst.cross_validation_fitted_values()
+
+    np.testing.assert_allclose(cv["LinearRegression"], cv["y"], atol=1e-12)
+    np.testing.assert_allclose(
+        fitted_values["LinearRegression"], fitted_values["y"], atol=1e-12
+    )
+
+
+def test_cv_no_refit_restores_fitted_state_after_prediction_error():
+    """A failure while using scratch state must not replace fitted state."""
+    n = 40
+    series = pd.DataFrame(
+        {
+            "unique_id": "series",
+            "ds": pd.date_range("2025-01-01", periods=n, freq="D"),
+            "y": np.arange(n, dtype=float),
+            "trend": np.arange(n, dtype=float),
+        }
+    )
+    fcst = MLForecast(
+        models=LinearRegression(),
+        freq="D",
+        target_transforms=[LocalStandardScaler()],
+    )
+    prediction_states = []
+
+    def fail_on_second_window(features):
+        prediction_states.append(fcst.ts)
+        if len(prediction_states) == 2:
+            raise RuntimeError("prediction failed")
+        return features
+
+    with pytest.raises(RuntimeError, match="prediction failed"):
+        fcst.cross_validation(
+            series,
+            n_windows=2,
+            h=1,
+            static_features=[],
+            refit=False,
+            before_predict_callback=fail_on_second_window,
+        )
+
+    assert len(prediction_states) == 2
+    assert prediction_states[0] is not prediction_states[1]
+    assert fcst.ts is prediction_states[0]
+
+
+@pytest.mark.parametrize(("fitted", "expected_calls"), [(False, 1), (True, 3)])
+def test_cv_no_refit_only_materializes_requested_fitted_values(
+    monkeypatch, fitted, expected_calls
+):
+    """Scratch windows only materialize training features for fitted values."""
+    from mlforecast.core import TimeSeries
+
+    calls = 0
+    original_transform = TimeSeries._transform
+
+    def track_transform(self, *args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original_transform(self, *args, **kwargs)
+
+    monkeypatch.setattr(TimeSeries, "_transform", track_transform)
+    n = 40
+    trend = np.arange(n, dtype=float)
+    series = pd.DataFrame(
+        {
+            "unique_id": "series",
+            "ds": pd.date_range("2025-01-01", periods=n, freq="D"),
+            "y": trend,
+            "trend": trend,
+        }
+    )
+    fcst = MLForecast(
+        models=LinearRegression(),
+        freq="D",
+        target_transforms=[LocalStandardScaler()],
+    )
+
+    fcst.cross_validation(
+        series,
+        n_windows=3,
+        h=2,
+        static_features=[],
+        refit=False,
+        fitted=fitted,
+    )
+
+    assert calls == expected_calls
+
+
+def test_cv_no_refit_requires_history_replay_for_custom_transform():
+    """Unsupported custom transforms fail with an actionable error."""
+
+    class IdentityTransformWithoutReplay(BaseTargetTransform):
+        def fit_transform(self, df):
+            return df
+
+        def update(self, df):
+            return df
+
+        def inverse_transform(self, df):
+            return df
+
+    n = 20
+    trend = np.arange(n, dtype=float)
+    series = pd.DataFrame(
+        {
+            "unique_id": "series",
+            "ds": pd.date_range("2025-01-01", periods=n, freq="D"),
+            "y": trend,
+            "trend": trend,
+        }
+    )
+    fcst = MLForecast(
+        models=LinearRegression(),
+        freq="D",
+        target_transforms=[IdentityTransformWithoutReplay()],
+    )
+
+    with pytest.raises(NotImplementedError, match="must implement _transform_history"):
+        fcst.cross_validation(
+            series,
+            n_windows=2,
+            h=1,
+            static_features=[],
+            refit=False,
+        )
+
+
+def test_cv_no_refit_supports_unaligned_series_history():
+    """Replay preserves panels whose series have different start dates."""
+    dates = pd.date_range("2025-01-01", periods=60, freq="D")
+    series = pd.concat(
+        [
+            pd.DataFrame(
+                {
+                    "unique_id": "a",
+                    "ds": dates,
+                    "y": np.arange(60, dtype=float),
+                }
+            ),
+            pd.DataFrame(
+                {
+                    "unique_id": "b",
+                    "ds": dates[10:],
+                    "y": np.arange(10, 60, dtype=float),
+                }
+            ),
+        ],
+        ignore_index=True,
+    )
+    fcst = MLForecast(
+        models=LinearRegression(),
+        freq="D",
+        lags=[1],
+        target_transforms=[LocalStandardScaler()],
+    )
+
+    cv = fcst.cross_validation(series, n_windows=3, h=2, refit=False)
+
+    assert cv.shape[0] == 12
+
+
 def test_cv_no_refit_honors_input_size():
     """``input_size`` must keep bounding the state used for non-refit windows.
 
@@ -820,15 +1027,16 @@ def test_cv_no_refit_honors_input_size():
     )
 
 
-def test_cv_no_refit_last_date_column_collision():
-    """A user column named ``_last_date`` must not collide with the update join."""
+@pytest.mark.parametrize("last_date_col", ["_last_date", "_mlforecast_last_date"])
+def test_cv_no_refit_last_date_column_collision(last_date_col):
+    """User columns must not collide with the internal update join column."""
     n = 60
     series = pd.DataFrame(
         {
             "unique_id": "series",
             "ds": pd.date_range("2025-01-01", periods=n, freq="D"),
             "y": np.arange(n, dtype=float),
-            "_last_date": 1.0,
+            last_date_col: 1.0,
         }
     )
     fcst = MLForecast(
@@ -843,6 +1051,74 @@ def test_cv_no_refit_last_date_column_collision():
     )
 
     assert cv.shape[0] == 6
+
+
+def test_target_transform_state_rejects_unknown_ids():
+    """Target-only updates must not silently discard unknown series."""
+    n = 20
+    series = pd.DataFrame(
+        {
+            "unique_id": "known",
+            "ds": pd.date_range("2025-01-01", periods=n, freq="D"),
+            "y": np.arange(n, dtype=float),
+        }
+    )
+    fcst = MLForecast(
+        models=LinearRegression(),
+        freq="D",
+        lags=[1],
+        target_transforms=[LocalStandardScaler()],
+    )
+    fcst.fit(series)
+    state = _TargetTransformState.from_time_series(fcst.ts)
+    unknown = pd.DataFrame(
+        {
+            "unique_id": "unknown",
+            "ds": [series["ds"].iloc[-1]],
+            "y": [0.0],
+        }
+    )
+
+    with pytest.raises(ValueError, match="new series.*unknown"):
+        state.new_observations(pd.concat([series, unknown], ignore_index=True))
+
+
+def test_cv_no_refit_honors_keep_last_n_with_target_transforms():
+    """Every scratch window must retain only the requested target history."""
+    n = 60
+    series = pd.DataFrame(
+        {
+            "unique_id": "series",
+            "ds": pd.date_range("2025-01-01", periods=n, freq="D"),
+            "y": np.arange(n, dtype=float),
+        }
+    )
+    fcst = MLForecast(
+        models=LinearRegression(),
+        freq="D",
+        lags=[1],
+        target_transforms=[LocalStandardScaler()],
+    )
+    window_states = []
+    retained_lengths = []
+
+    def record_retained_history(features):
+        if not any(fcst.ts is state for state in window_states):
+            window_states.append(fcst.ts)
+            retained_lengths.extend(np.diff(fcst.ts.ga.indptr))
+        return features
+
+    fcst.cross_validation(
+        series,
+        n_windows=3,
+        h=2,
+        refit=False,
+        keep_last_n=5,
+        before_predict_callback=record_retained_history,
+    )
+
+    assert len(window_states) == 3
+    assert retained_lengths == [5, 5, 5]
 
 
 @pytest.mark.parametrize("refit", [True, False])

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -688,6 +688,163 @@ def test_prediction_intervals_preserve_target_transform_state():
         np.testing.assert_allclose(preds[col], expected)
 
 
+def test_cv_no_refit_polars_categorical_id():
+    """Non-refit CV must not break on a polars ``Categorical`` id column.
+
+    ``TimeSeries.update`` normalizes ids through ``match_if_categorical``, whose
+    polars branch recasts inside a temporary ``pl.StringCache()``. Advancing
+    ``self.ts`` therefore rewrites ``self.ts.uids`` against a cache that is gone
+    by the time ``cross_validation`` joins the predictions with ``cutoffs``.
+    """
+    n = 60
+    frames = [
+        pd.DataFrame(
+            {
+                "unique_id": uid,
+                "ds": pd.date_range("2025-01-01", periods=n, freq="D"),
+                "y": np.arange(n, dtype=float) + 10 * i,
+            }
+        )
+        for i, uid in enumerate(["a", "b"])
+    ]
+    series = pl.from_pandas(pd.concat(frames, ignore_index=True)).with_columns(
+        pl.col("unique_id").cast(pl.Categorical)
+    )
+    fcst = MLForecast(
+        models=LinearRegression(),
+        freq="1d",
+        lags=[1],
+        target_transforms=[LocalStandardScaler()],
+    )
+
+    cv = fcst.cross_validation(series, n_windows=3, h=2, refit=False)
+
+    assert cv.shape[0] == 2 * 3 * 2
+
+
+def test_cv_no_refit_fitted_values_preserve_target_transform_state():
+    """Fitted values must use the transform state fitted with the frozen models.
+
+    ``_compute_fitted_values`` runs before the ``self.ts`` restore, so it inverse
+    transforms with the copy whose transforms were refit on the expanded window
+    while the models are still fitted on the first window.
+    """
+    n = 100
+    trend = np.arange(n, dtype=float)
+    series = pd.DataFrame(
+        {
+            "unique_id": "series",
+            "ds": pd.date_range("2025-01-01", periods=n, freq="D"),
+            "y": trend,
+            "trend": trend,
+        }
+    )
+    fcst = MLForecast(
+        models=LinearRegression(),
+        freq="D",
+        target_transforms=[LocalStandardScaler()],
+    )
+
+    fcst.cross_validation(
+        series,
+        n_windows=5,
+        h=2,
+        step_size=1,
+        static_features=[],
+        refit=False,
+        fitted=True,
+    )
+    fitted_values = fcst.cross_validation_fitted_values()
+
+    np.testing.assert_allclose(
+        fitted_values["LinearRegression"].to_numpy(),
+        fitted_values["y"].to_numpy(),
+        atol=1e-6,
+    )
+
+
+def test_cv_no_refit_honors_input_size():
+    """``input_size`` must keep bounding the state used for non-refit windows.
+
+    ``Differences`` is parameter free: refitting it on any window yields the same
+    transformed target, so predicting each window from its own truncated history
+    is a correct reference here and any mismatch isolates the state bound.
+    ``ExpandingMean`` makes the retained history observable in the features.
+    """
+    n = 120
+    rng = np.random.default_rng(0)
+    series = pd.DataFrame(
+        {
+            "unique_id": "series",
+            "ds": pd.date_range("2025-01-01", periods=n, freq="D"),
+            "y": np.arange(n, dtype=float) + rng.normal(size=n),
+        }
+    )
+    kwargs = dict(
+        freq="D",
+        lags=[1],
+        lag_transforms={1: [ExpandingMean()]},
+        target_transforms=[Differences([1])],
+    )
+    input_size, n_windows, h = 35, 4, 1
+
+    actual = MLForecast(models=LinearRegression(), **kwargs).cross_validation(
+        series,
+        n_windows=n_windows,
+        h=h,
+        step_size=1,
+        refit=False,
+        input_size=input_size,
+    )
+
+    ref_fcst = MLForecast(models=LinearRegression(), **kwargs)
+    expected = []
+    splits = ufp.backtest_splits(
+        series,
+        n_windows=n_windows,
+        h=h,
+        id_col="unique_id",
+        time_col="ds",
+        freq=ref_fcst.freq,
+        step_size=1,
+        input_size=input_size,
+    )
+    for i_window, (_cutoffs, train, _valid) in enumerate(splits):
+        if i_window == 0:
+            ref_fcst.fit(train)
+        preds = ref_fcst.predict(h=h, new_df=None if i_window == 0 else train)
+        expected.append(preds["LinearRegression"].to_numpy())
+
+    np.testing.assert_allclose(
+        actual["LinearRegression"].to_numpy(), np.concatenate(expected)
+    )
+
+
+def test_cv_no_refit_last_date_column_collision():
+    """A user column named ``_last_date`` must not collide with the update join."""
+    n = 60
+    series = pd.DataFrame(
+        {
+            "unique_id": "series",
+            "ds": pd.date_range("2025-01-01", periods=n, freq="D"),
+            "y": np.arange(n, dtype=float),
+            "_last_date": 1.0,
+        }
+    )
+    fcst = MLForecast(
+        models=LinearRegression(),
+        freq="D",
+        lags=[1],
+        target_transforms=[LocalStandardScaler()],
+    )
+
+    cv = fcst.cross_validation(
+        series, n_windows=3, h=2, static_features=[], refit=False
+    )
+
+    assert cv.shape[0] == 6
+
+
 @pytest.mark.parametrize("refit", [True, False])
 def test_cv_weight_col(refit):
     """Test that cross_validation works with weight_col and weights are used.
@@ -2880,7 +3037,9 @@ def test_drop_auxiliary_columns_cross_validation(aux_cols_series):
         lags=[1, 7],
         lag_transforms={1: [RollingMean(7, groupby=[groupby_col])]},
     )
-    cv_result = fcst.cross_validation(aux_cols_series, n_windows=2, h=7, static_features=statics)
+    cv_result = fcst.cross_validation(
+        aux_cols_series, n_windows=2, h=7, static_features=statics
+    )
     assert cv_result is not None
     assert groupby_col not in cv_result.columns
     for i in range(2):

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -614,6 +614,80 @@ def test_cv_no_refit(setup_forecast_data):
     )
 
 
+@pytest.mark.parametrize("engine", ["pandas", "polars"])
+@pytest.mark.parametrize("fitted", [False, True])
+@pytest.mark.parametrize("difference", [False, True])
+def test_cv_no_refit_preserves_target_transform_state(engine, fitted, difference):
+    n = 100
+    trend = np.arange(n, dtype=float)
+    series = pd.DataFrame(
+        {
+            "unique_id": "series",
+            "ds": pd.date_range("2025-01-01", periods=n, freq="D"),
+            "y": trend**2,
+            "trend": trend,
+            "trend_squared": trend**2,
+        }
+    )
+    target_transforms = [LocalStandardScaler()]
+    if difference:
+        target_transforms.insert(0, Differences([1]))
+    fcst = MLForecast(
+        models=LinearRegression(),
+        freq="1d" if engine == "polars" else "D",
+        target_transforms=target_transforms,
+    )
+    if engine == "polars":
+        series = pl.from_pandas(series)
+
+    cv = fcst.cross_validation(
+        series,
+        n_windows=20,
+        h=2,
+        step_size=1,
+        static_features=[],
+        refit=False,
+        fitted=fitted,
+    )
+
+    np.testing.assert_allclose(cv["LinearRegression"].to_numpy(), cv["y"].to_numpy())
+
+
+def test_prediction_intervals_preserve_target_transform_state():
+    n = 100
+    series = pd.DataFrame(
+        {
+            "unique_id": "series",
+            "ds": pd.date_range("2025-01-01", periods=n, freq="D"),
+            "y": np.arange(n, dtype=float),
+            "trend": np.arange(n, dtype=float),
+        }
+    )
+    future = pd.DataFrame(
+        {
+            "unique_id": "series",
+            "ds": pd.date_range("2025-04-11", periods=2, freq="D"),
+            "trend": [100.0, 101.0],
+        }
+    )
+    fcst = MLForecast(
+        models=LinearRegression(),
+        freq="D",
+        target_transforms=[LocalStandardScaler()],
+    )
+
+    fcst.fit(
+        series,
+        static_features=[],
+        prediction_intervals=PredictionIntervals(n_windows=20, h=2),
+    )
+    preds = fcst.predict(h=2, X_df=future, level=[80])
+
+    expected = np.array([100.0, 101.0])
+    for col in ["LinearRegression", "LinearRegression-lo-80", "LinearRegression-hi-80"]:
+        np.testing.assert_allclose(preds[col], expected)
+
+
 @pytest.mark.parametrize("refit", [True, False])
 def test_cv_weight_col(refit):
     """Test that cross_validation works with weight_col and weights are used.

--- a/tests/test_pooled.py
+++ b/tests/test_pooled.py
@@ -3298,6 +3298,52 @@ def test_target_transforms_with_pooled_predict(engine):
     )
 
 
+@pytest.mark.parametrize("engine", ["pandas", "polars"])
+def test_target_transforms_with_pooled_cv_no_refit(engine):
+    """Frozen-model CV warms pooled state from replayed target history."""
+    from mlforecast import MLForecast
+    from mlforecast.target_transforms import Differences
+    from sklearn.linear_model import LinearRegression
+
+    n_times = 30
+    ids = np.repeat(["a", "b"], n_times)
+    times = np.tile(np.arange(n_times), 2)
+    y = np.concatenate([3.0 * np.arange(n_times), 100.0 + 3.0 * np.arange(n_times)])
+    promos = np.tile([0, 1], n_times)
+    df = _make_df(
+        engine,
+        {
+            "unique_id": ids.tolist(),
+            "ds": times.tolist(),
+            "y": y.tolist(),
+            "promo": promos.tolist(),
+        },
+    )
+    fcst = MLForecast(
+        models=[LinearRegression()],
+        freq=1,
+        target_transforms=[Differences([1])],
+        lag_transforms={
+            1: [
+                RollingMean(2, min_samples=1, global_=True),
+                RollingMean(2, min_samples=1, partition_by=["promo"]),
+            ]
+        },
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        cv = fcst.cross_validation(
+            df,
+            n_windows=3,
+            h=2,
+            static_features=[],
+            refit=False,
+        )
+
+    assert cv.shape[0] == 12
+
+
 def _range_quantile_oracle(
     hist, qid, qt, qpromo, mode, p=0.5, lag=1, window=3, min_samples=1
 ):


### PR DESCRIPTION
Closes #733.

## What changed

- Keep the target-transform state fitted with each frozen estimator during
  `cross_validation(refit=False)` and periodic-refit cross-validation.
- Advance target state independently from `TimeSeries`, using only observations
  added since the previous window.
- Add an internal `_transform_history` contract that applies learned transform
  parameters to a bounded historical window while rebuilding runtime state used
  for prediction and fitted-value inversion.
- Build a scratch `TimeSeries` for each non-refit window instead of mutating the
  fitted instance.
- Warm only prediction state when `fitted=False`; materialize training features
  only when cross-validation fitted values are requested.
- Share update ID normalization, group sizing, new-series detection, and last-date
  advancement with `TimeSeries.update`.

## Why

The first cross-validation window fits the estimator and target transforms
together. Later non-refit windows previously called `predict(new_df=train)`, which
refit target transforms on each window while reusing the estimator from the first
window. Learned transforms such as `LocalStandardScaler` therefore moved to a new
target scale without refitting the estimator, creating artificial conformity
errors and severely inflated conformal intervals.

Advancing the fitted transform state in place fixes the scale mismatch for aligned
expanding panels, but changes other cross-validation semantics. In particular, it
mutates the fitted `TimeSeries`, breaks Polars categorical IDs, stops `input_size`
and `keep_last_n` from bounding window state, and leaves fitted-value inversion on
the wrong transform state.

The scratch-window implementation keeps the estimator and learned transform
parameters frozen while rebuilding exactly the feature and target runtime state
required by each bounded cross-validation window.

## Behavior covered

- pandas and Polars, including Polars categorical IDs
- scaling alone and scaling composed with `Differences`
- auto-differencing transforms without relearning their selected differences
- `refit=False` and periodic integer refits
- overlapping windows
- `fitted=False` and `fitted=True`
- `input_size` and `keep_last_n`
- pooled lag transforms
- unaligned series histories
- collision-safe internal columns and explicit unknown-series errors
- restoration of the fitted `TimeSeries` when prediction raises
- actionable failure for custom transforms without historical replay support

## Validation

- Ruff formatting and lint checks pass for all modified files.
- 186 core and target-transform tests pass.
- 35 focused frozen-model cross-validation tests pass.
- 7 pooled target-transform tests pass.

